### PR TITLE
Fix docu: type of struct returned by nut_info()

### DIFF
--- a/screws.scad
+++ b/screws.scad
@@ -1884,7 +1884,7 @@ function screw_info(name, head, drive, thread, drive_size, shaft_oversize, head_
 //   . 
 //   Field              | What it is
 //   ------------------ | ---------------
-//   "type"           | Always set to "screw_info"
+//   "type"           | Always set to "nut_info"
 //   "system"         | Either `"UTS"` or `"ISO"` (used for correct tolerance computation).
 //   "origin"         | Module that created the structure
 //   "name"           | Name used to specify threading, such as "M6" or "#8"


### PR DESCRIPTION
nut_info() returns a struct with type `nut_info`.

The documentation, however, mentions that the struct is of type `screw_info`. This might be a copy-paste issue.

Test that proves the implemented behaviour:

```
include <BOSL2/std.scad>
include <BOSL2/screws.scad>

assert(struct_val(nut_info("M3"), "type", "undefined") == "nut_info");
```