### PR TITLE
correct error creating worm gear with shaft

### DIFF
--- a/gears.scad
+++ b/gears.scad
@@ -1774,7 +1774,7 @@ module worm_gear(
         difference() {
             vnf_polyhedron(vnf, convexity=teeth/2);
             if (shaft_diam > 0) {
-                cylinder(d=shaft_diam, l=worm_diam, center=true);
+                cylinder(d=shaft_diam, h=worm_diam, center=true);
             }
         }
         children();

--- a/gears.scad
+++ b/gears.scad
@@ -1774,7 +1774,7 @@ module worm_gear(
         difference() {
             vnf_polyhedron(vnf, convexity=teeth/2);
             if (shaft_diam > 0) {
-                cylinder(d=shaft_diam, h=worm_diam, center=true);
+                cylinder(h=2*thickness+1, r=shaft_diam/2, center=true, $fn=max(12,segs(shaft_diam/2)));
             }
         }
         children();


### PR DESCRIPTION
corrects bug  #1201

Also makes the change that the height of the cylinder differenced for the shaft is based on the thickness & $fn is limited (copied from bevel_gear)

Noob, sorry if any of this is incorrect in functionality or process. 