### PR TITLE
Fix vertext range assert false positive when `associate_vertices` is passed empty split

### DIFF
--- a/skin.scad
+++ b/skin.scad
@@ -2677,7 +2677,7 @@ function associate_vertices(polygons, split, curpoly=0) =
     assert(len(cursplit)+polylen == len(polygons[curpoly+1]),
            str("Polygon ", curpoly, " has ", polylen, " vertices.  Next polygon has ", len(polygons[curpoly+1]),
                   " vertices.  Split list has length ", len(cursplit), " but must have length ", len(polygons[curpoly+1])-polylen))
-    assert(max(cursplit)<polylen && min(curpoly)>=0,
+    assert(len(cursplit) == 0 || max(cursplit)<polylen && min(curpoly)>=0,
            str("Split ",cursplit," at polygon ",curpoly," has invalid vertices.  Must be in [0:",polylen-1,"]"))
     len(cursplit)==0 ? associate_vertices(polygons,split,curpoly+1) :
     let(


### PR DESCRIPTION
When `associate_vertices` function is passed an empty split vector between polygons, an assert fails due to how `min` and `max` functions return `undef` when passed an empty vector. Comparing this result with a number will always return `false` and fail the assert.

I detected an issue in OpenSCAD version `2021.01`.

Minimum code to reproduce:
```openscad
include <BOSL2/std.scad>
path = associate_vertices([square(20), square(10)], [[]]);
```

Log:
```
WARNING: max() parameter could not be converted in file skin.scad, line 2680
WARNING: undefined operation (undefined < number) in file .../BOSL2/skin.scad, line 2680
ERROR: Assertion '((max(cursplit) < polylen) && (min(curpoly) >= 0))' failed: "Split [] at polygon 0 has invalid vertices. Must be in [0:3]" in file .../BOSL2/skin.scad, line 2680
```