### PR TITLE
add r, d, & h parameters to pco1810_cap()

### DIFF
--- a/bottlecaps.scad
+++ b/bottlecaps.scad
@@ -147,10 +147,13 @@ function  pco1810_neck(wall=2, anchor="support-ring", spin=0, orient=UP) =
 // Topics: Bottles, Threading
 // See Also: pco1810_neck()
 // Usage:
-//   pco1810_cap([wall], [texture]) [ATTACHMENTS];
+//   pco1810_cap([h], [r|d], [wall], [texture]) [ATTACHMENTS];
 // Description:
 //   Creates a basic cap for a PCO1810 threaded beverage bottle.
 // Arguments:
+//   h = The height of the cap.
+//   r = Outer radius of the cap.
+//   d = Outer diameter of the cap.
 //   wall = Wall thickness in mm.
 //   texture = The surface texture of the cap.  Valid values are "none", "knurled", or "ribbed".  Default: "none"
 //   ---
@@ -169,7 +172,7 @@ function  pco1810_neck(wall=2, anchor="support-ring", spin=0, orient=UP) =
 //   expose_anchors(0.3)
 //       pco1810_cap(texture="ribbed")
 //           show_anchors(std=false);
-module pco1810_cap(wall=2, texture="none", anchor=BOTTOM, spin=0, orient=UP)
+module pco1810_cap(h, r, d, wall, texture="none", anchor=BOTTOM, spin=0, orient=UP)
 {
     cap_id = 28.58;
     tamper_ring_h = 14.10;
@@ -178,33 +181,39 @@ module pco1810_cap(wall=2, texture="none", anchor=BOTTOM, spin=0, orient=UP)
     thread_od = cap_id;
     thread_depth = 1.6;
 
+    rr = get_radius(r=r, d=d, dflt=undef);
+    wwall = default(u_sub(rr,cap_id/2), default(wall, 2));
+    hh = default(h, tamper_ring_h + wwall);
+    checks =
+        assert(wwall >= 0, "wall can't be negative.")
+        assert(hh >= tamper_ring_h, str("height can't be less than ", tamper_ring_h, "."));
+
     $fn = segs(33/2);
-    w = cap_id + 2*wall;
-    h = tamper_ring_h + wall;
+    w = cap_id + 2*wwall;
     anchors = [
-        named_anchor("inside-top", [0,0,-(h/2-wall)])
+        named_anchor("inside-top", [0,0,-(hh/2-wwall)])
     ];
-    attachable(anchor,spin,orient, d=w, l=h, anchors=anchors) {
-        down(h/2) zrot(45) {
+    attachable(anchor,spin,orient, d=w, l=hh, anchors=anchors) {
+        down(hh/2) zrot(45) {
             difference() {
                 union() {
                     if (texture == "knurled") {
-                        cyl(d=w, h=h, texture="diamonds", tex_size=[3,3], tex_style="concave", anchor=BOT);
+                        cyl(d=w, h=hh, texture="diamonds", tex_size=[3,3], tex_style="concave", anchor=BOT);
                     } else if (texture == "ribbed") {
-                        cyl(d=w, h=h, texture="ribs", tex_size=[3,3], tex_style="min_edge", anchor=BOT);
+                        cyl(d=w, h=hh, texture="ribs", tex_size=[3,3], tex_style="min_edge", anchor=BOT);
                     } else {
-                        cyl(d=w, l=tamper_ring_h+wall, anchor=BOTTOM);
+                        cyl(d=w, l=hh, anchor=BOTTOM);
                     }
                 }
-                up(wall) cyl(d=cap_id, h=tamper_ring_h+wall, anchor=BOTTOM);
+                up(hh-tamper_ring_h) cyl(d=cap_id, h=tamper_ring_h+wwall, anchor=BOTTOM);
             }
-            up(wall+2) thread_helix(d=thread_od-thread_depth*2, pitch=thread_pitch, thread_depth=thread_depth, flank_angle=flank_angle, turns=810/360, lead_in=-thread_depth, internal=true, anchor=BOTTOM);
+            up(hh-tamper_ring_h+2) thread_helix(d=thread_od-thread_depth*2, pitch=thread_pitch, thread_depth=thread_depth, flank_angle=flank_angle, turns=810/360, lead_in=-thread_depth, internal=true, anchor=BOTTOM);
         }
         children();
     }
 }
 
-function pco1810_cap(wall=2, texture="none", anchor=BOTTOM, spin=0, orient=UP) =
+function pco1810_cap(h, r, d, wall, texture="none", anchor=BOTTOM, spin=0, orient=UP) =
     no_function("pco1810_cap");
 
 


### PR DESCRIPTION
Fully backwards compatible. The parameters are optional and r|d are mutually exclusive with the wall parameter.