### PR TITLE
Propagate "style" in recursive sweep()

### DIFF
--- a/skin.scad
+++ b/skin.scad
@@ -2099,7 +2099,7 @@ function sweep(shape, transforms, closed=false, caps, style="min_edge",
         capsOK = is_bool(caps) || is_bool_list(caps,2),
         fullcaps = is_bool(caps) ? [caps,caps] : caps
     )
-    assert(len(transforms), "transformation must be length 2 or more")
+    assert(len(transforms)>=2, "transformation must be length 2 or more")
     assert(capsOK, "caps must be boolean or a list of two booleans")
     assert(!closed || !caps, "Cannot make closed shape with caps")
     is_region(shape)? let(
@@ -2108,7 +2108,7 @@ function sweep(shape, transforms, closed=false, caps, style="min_edge",
         vnfs = [
             for (rgn=regions) each [
                 for (path=rgn)
-                    sweep(path, transforms, closed=closed, caps=false),
+                    sweep(path, transforms, closed=closed, caps=false, style=style),
                 if (fullcaps[0]) vnf_from_region(rgn, transform=transforms[0], reverse=true),
                 if (fullcaps[1]) vnf_from_region(rgn, transform=last(transforms)),
             ],

--- a/tests/test_skin.scad
+++ b/tests/test_skin.scad
@@ -16,4 +16,21 @@ module test_skin() {
 test_skin();
 
 
+module test_sweep() {
+    multi_region = [
+        [[10, 0], [ 0, 0], [ 0, 10], [10, 10]],
+        [[30, 0], [20, 0], [20, 10], [30, 10]]
+    ];
+    transforms = [ up(10), down(10) ];
+
+    vnf1 = sweep(multi_region,transforms,closed=false,caps=false);
+    assert(len(vnf1[0])==8*2 && len(vnf1[1])==8*2);
+
+    vnf2 = sweep(multi_region,transforms,closed=false,caps=false,style="quincunx");
+    assert(len(vnf2[0])==8*3 && len(vnf2[1])==8*4);
+}
+test_sweep();
+
+
+
 // vim: expandtab tabstop=4 shiftwidth=4 softtabstop=4 nowrap


### PR DESCRIPTION
- skin.scad/sweep() takes a "style" parameter which was not propagated correctly when used recursively on a region with multiple parts.

- Testing for transform list length did not match the comment.

- Added a simple test case for sweep()