### PR TITLE
Add Ext Syntags

### DIFF
--- a/.openscad_docsgen_rc
+++ b/.openscad_docsgen_rc
@@ -68,6 +68,7 @@ DefineHeader(Table;Headers=Anchor Type|What it is): Anchor Types
 DefineHeader(Table;Headers=Name|Definition): Terminology
 DefineHeader(BulletList): Requirements
 DefineSynTags:
+  Ext = Extends the OpenScad keyword of the same name.
   Geom = Can return geometry.
   Mat = Can return a transformation matrix.
   MatList = Can return a list of transformation matrices.

--- a/attachments.scad
+++ b/attachments.scad
@@ -1311,8 +1311,8 @@ module tag_intersect(tag,intersect="intersect",keep="keep")
 
 // Module: conv_hull()
 // Synopsis:  Performs a hull operation on the children using tags to determine what happens.
-// Topics: Attachments
-// See Also: tag(), recolor(), show_only(), hide(), diff(), intersect()
+// Topics: Attachments, Hulling
+// See Also: tag(), recolor(), show_only(), hide(), diff(), intersect(), hull()
 // Usage:
 //   conv_hull([keep]) CHILDREN;
 // Description:

--- a/geometry.scad
+++ b/geometry.scad
@@ -2339,8 +2339,9 @@ function ___is_polygon_in_list(poly, polys, i) =
 
 // Function: hull()
 // Synopsis: Convex hull of a list of 2d or 3d points.
+// Syntags: Ext,
 // Topics: Geometry, Hulling
-// See Also: hull(), hull_points(), hull2d_path(), hull3d_faces()
+// See Also: hull_points(), hull2d_path(), hull3d_faces()
 // Usage:
 //   face_list_or_index_list = hull(points);
 // Description:

--- a/regions.scad
+++ b/regions.scad
@@ -755,7 +755,7 @@ function _point_dist(path,pathseg_unit,pathseg_len,pt) =
 
 // Function: offset()
 // Synopsis: Takes a 2D path, polygon or region and returns a path offset by an amount.
-// SynTags: Path, Region
+// SynTags: Path, Region, Ext
 // Topics: Paths, Polygons, Regions
 // Usage:
 //   offsetpath = offset(path, [r=|delta=], [chamfer=], [closed=], [check_valid=], [quality=], [same_length=])

--- a/shapes2d.scad
+++ b/shapes2d.scad
@@ -22,7 +22,7 @@ use <builtins.scad>
 
 // Function&Module: square()
 // Synopsis: Creates a 2D square or rectangle.
-// SynTags: Geom, Path
+// SynTags: Geom, Path, Ext
 // Topics: Shapes (2D), Path Generators (2D)
 // See Also: rect()
 // Usage: As a Module
@@ -32,7 +32,7 @@ use <builtins.scad>
 // Usage: As a Function
 //   path = square(size, [center], ...);
 // Description:
-//   When called as the builtin module, creates a 2D square or rectangle of the given size.
+//   When called as the built-in module, creates a 2D square or rectangle of the given size.
 //   When called as a function, returns a 2D path/list of points for a square/rectangle of the given size.
 // Arguments:
 //   size = The size of the square to create.  If given as a scalar, both X and Y will be the same size.
@@ -224,7 +224,7 @@ function rect(size=1, rounding=0, chamfer=0, atype="box", anchor=CENTER, spin=0,
 
 // Function&Module: circle()
 // Synopsis: Creates the approximation of a circle.
-// SynTags: Geom, Path
+// SynTags: Geom, Path, Ext
 // Topics: Shapes (2D), Path Generators (2D)
 // See Also: ellipse(), circle_2tangents(), circle_3points()
 // Usage: As a Module
@@ -236,7 +236,7 @@ function rect(size=1, rounding=0, chamfer=0, atype="box", anchor=CENTER, spin=0,
 //   path = circle(points=);
 //   path = circle(r|d=, corner=);
 // Description:
-//   When called as the builtin module, creates a 2D polygon that approximates a circle of the given size.
+//   When called as the built-in module, creates a 2D polygon that approximates a circle of the given size.
 //   When called as a function, returns a 2D list of points (path) for a polygon that approximates a circle of the given size.
 //   If `corner=` is given three 2D points, centers the circle so that it will be tangent to both segments of the path, on the inside corner.
 //   If `points=` is given three 2D points, centers and sizes the circle so that it passes through all three points.

--- a/shapes3d.scad
+++ b/shapes3d.scad
@@ -19,7 +19,7 @@ use <builtins.scad>
 
 // Function&Module: cube()
 // Synopsis: Creates a cube with anchors for attaching children.
-// SynTags: Geom, VNF
+// SynTags: Geom, VNF, Ext
 // Topics: Shapes (3D), Attachable, VNF Generators
 // See Also: cuboid(), prismoid()
 // Usage: As Module (as in native OpenSCAD)
@@ -1184,7 +1184,7 @@ function wedge(size=[1,1,1], center, anchor, spin=0, orient=UP) =
 
 // Function&Module: cylinder()
 // Synopsis: Creates an attachable cylinder.
-// SynTags: Geom, VNF
+// SynTags: Geom, VNF, Ext
 // Topics: Shapes (3D), Attachable, VNF Generators
 // See Also: cyl()
 // Usage: As Module (as in native OpenSCAD)
@@ -2155,7 +2155,7 @@ function pie_slice(
 
 // Function&Module: sphere()
 // Synopsis: Creates an attachable spherical object.
-// SynTags: Geom, VNF
+// SynTags: Geom, VNF, Ext
 // Topics: Shapes (3D), Attachable, VNF Generators
 // See Also: spheroid()
 // Usage: As Module (native OpenSCAD)

--- a/transforms.scad
+++ b/transforms.scad
@@ -779,7 +779,7 @@ function tilt(to, cp, reverse=false, p=_NO_ARG) =
 // Function&Module: scale()
 //
 // Synopsis: Scales children arbitrarily.
-// SynTags: Trans, Path, VNF, Mat
+// SynTags: Trans, Path, VNF, Mat, Ext
 // Topics: Affine, Matrices, Transforms, Scaling
 // See Also: xscale(), yscale(), zscale()
 //
@@ -1008,7 +1008,7 @@ function zscale(z=1, p=_NO_ARG, cp=0) =
 // Function&Module: mirror()
 //
 // Synopsis: Reflects children across an arbitrary plane.
-// SynTags: Trans, Path, VNF, Mat
+// SynTags: Trans, Path, VNF, Mat, Ext
 // Topics: Affine, Matrices, Transforms, Reflection, Mirroring
 // See Also: xflip(), yflip(), zflip()
 //

--- a/version.scad
+++ b/version.scad
@@ -9,7 +9,7 @@
 //////////////////////////////////////////////////////////////////////
 
 
-BOSL_VERSION = [2,0,672];
+BOSL_VERSION = [2,0,673];
 
 
 // Section: BOSL Library Version Functions

--- a/version.scad
+++ b/version.scad
@@ -9,7 +9,7 @@
 //////////////////////////////////////////////////////////////////////
 
 
-BOSL_VERSION = [2,0,673];
+BOSL_VERSION = [2,0,674];
 
 
 // Section: BOSL Library Version Functions


### PR DESCRIPTION
New Syntag Ext for BOSL2 modules/functions that extend OpenSCAD keywords of the same name.