### PR TITLE
Prune undefined values thru struct_set

### DIFF
--- a/structs.scad
+++ b/structs.scad
@@ -50,7 +50,10 @@ function struct_set(struct, key, value, grow=true) =
   :
   assert(is_list(key) && len(key)%2==0, "[key,value] pair list is not a list or has an odd length")
   let(
-      new_entries = [for(i=[0:1:len(key)/2-1]) [key[2*i], key[2*i+1]]],
+      new_entries = [for(i=[0:1:len(key)/2-1]) if (is_def(key[2*i+1])) [key[2*i], key[2*i+1]]]
+  )
+  len(new_entries) == 0 ? struct :
+  let(
       newkeys = column(new_entries,0),
       indlist = search(newkeys, struct,0,0),
       badkeys = grow ? (search([undef],new_entries,1,0)[0] != [] ? [undef] : [])

--- a/tests/test_structs.scad
+++ b/tests/test_structs.scad
@@ -19,6 +19,10 @@ module test_struct_set() {
     assert(st7 == [["Bar", 28],["Foo",91],[3,4],[[5,7],99]]);
     st8 = struct_set(st3,[]);
     assert(st8==st3);
+    st9 = struct_set(st2, ["Baz", undef]);
+    assert(st9 == st2);
+    st10 = struct_set(st2, ["Foo", 91, "Baz", undef]);
+    assert(st10 == st3);
 }
 test_struct_set();
 


### PR DESCRIPTION
Avoid adding `[key, undef]` pairs to structs.