### PR TITLE
Propagate information about partition() part to children()

### DIFF
--- a/constants.scad
+++ b/constants.scad
@@ -257,4 +257,14 @@ RAY = [true, false];
 LINE = [false, false];
 
 
+// Constant: FIRST
+// Synopsis: A constant specifying the first part in partition(). `1`.
+FIRST = 1;
+
+
+// Constant: SECOND
+// Synopsis: A constant specifying the second part in partition(). `2`.
+SECOND = 2;
+
+
 // vim: expandtab tabstop=4 shiftwidth=4 softtabstop=4 nowrap

--- a/partitions.scad
+++ b/partitions.scad
@@ -566,12 +566,14 @@ module partition(size=100, spread=10, cutsize=10, cutpath="jigsaw", gap=0, spin=
     rsize = v_abs(rot(spin,p=size));
     vec = rot(spin,p=BACK)*spread/2;
     move(vec) {
+        $partition_part = FIRST;
         intersection() {
             children();
             partition_mask(l=rsize.x, w=rsize.y, h=rsize.z, cutsize=cutsize, cutpath=cutpath, gap=gap, spin=spin);
         }
     }
     move(-vec) {
+        $partition_part = SECOND;
         intersection() {
             children();
             partition_mask(l=rsize.x, w=rsize.y, h=rsize.z, cutsize=cutsize, cutpath=cutpath, gap=gap, inverse=true, spin=spin);


### PR DESCRIPTION
This patch allows to customize the partitioned parts. The part is available in `$partition_part` variable and is either `FIRST` or `SECOND`).