### PR TITLE
Documentation, argument order, and demo changes in vnf_tri_array

### DIFF
--- a/vnf.scad
+++ b/vnf.scad
@@ -98,7 +98,7 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //       for(h=[-20:20:20])
 //           path3d(arc(r=40-abs(h), angle=280, 10), h)
 //   ];
-//   vnf = vnf_vertex_array(rows, reverse=true, caps=true, col_wrap-true);
+//   vnf = vnf_vertex_array(rows, reverse=true, caps=true, col_wrap=true);
 //   vnf_polyhedron(vnf);
 //   color("green") vnf_wireframe(vnf);
 // Example(3D): Both `col_wrap` and `row_wrap` are true to make a torus.


### PR DESCRIPTION
* Re-ordered args in vnf_tri_array() for consistency with vnf_vertex_array()
* Using same arg handing logic as in vnf_vertex_array()
* Edited arg documentation in vnf_tri_array() for consistency with vnf_vertex_array
* Modified wrapping and capping demos to use equal-length arcs, removed them from vnf_tri_array(), moved them into vnf_vertex_array()
* Changed viewport distance for cymbal example, made image medium size
