### PR TITLE
spur_gear: fix missing shorten parameter

### DIFF
--- a/gears.scad
+++ b/gears.scad
@@ -1054,6 +1054,7 @@ module spur_gear(
                         clearance = clearance,
                         backlash = backlash,
                         internal = internal,
+                        shorten = shorten,
                         profile_shift = profile_shift,
                         shaft_diam = shaft_diam
                     );


### PR DESCRIPTION
Fix missing `shorten` parameter when calling `spur_gear_2d` from `spur_gear` function.