### PR TITLE
Grammar fix, corrections to rounding and shapes2d examples

### DIFF
--- a/beziers.scad
+++ b/beziers.scad
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////
 // LibFile: beziers.scad
-//   Bezier curves and surfaces are way to represent smooth curves and smoothly curving
+//   Bezier curves and surfaces are ways to represent smooth curves and smoothly curving
 //   surfaces with a set of control points.  The curve or surface is defined by
 //   the control points, but usually only passes through the first and last control point (the endpoints).
 //   This file provides some

--- a/shapes2d.scad
+++ b/shapes2d.scad
@@ -1792,7 +1792,7 @@ module glued_circles(r, spread=10, tangent=30, d, anchor=CENTER, spin=0) {
 // Examples(2D):
 //   squircle(size=50, squareness=0.4);
 //   squircle([80,60], 0.7, $fn=64);
-// Example(3D,VPD=48,VPR=[40,0,40],NoAxes): Corner differences between the three squircle styles for squareness=0.5. Style "superellipse" is pink, "fg" is gold, "bezier" is blue.
+// Example(3D,VPD=48,VPR=[40,0,40],VPT=[11,-11,-10],NoAxes): Corner differences between the three squircle styles for squareness=0.5. Style "superellipse" is pink, "fg" is gold, "bezier" is blue.
 //   color("pink") squircle(size=50, style="superellipse", squareness=0.5, $fn=256);
 //   color("yellow") up(1) squircle(size=50, style="fg", squareness=0.5, $fn=256);
 //   color("lightblue") up(2) squircle(size=50, style="bezier", squareness=0.5, $fn=256);


### PR DESCRIPTION
* Fixed a grammar error in beziers.scad
* Set camera translation correctly in one squircle example in shapes2d.scad
* Multiple corrections to smooth_path examples in rounding.scad