### PR TITLE
New features: 2D contours and 2D metaballs

### DIFF
--- a/isosurface.scad
+++ b/isosurface.scad
@@ -1093,7 +1093,8 @@ function _contour_pixels(pixsize, bbox, fieldarray, fieldfunc, pixcenters, isova
                     // get center value of pixel
                     if (pixcenters)
                         is_def(fieldfunc)
-                            ? fieldfunc(x+hp, y+hp) : 0.25*(f0 + f1 + f2 + f3)
+                            ? min(1e9,max(-1e9,fieldfunc(x+hp.x, y+hp.y)))
+                            : 0.25*(f0 + f1 + f2 + f3)
                 ],
                 pixcoord = [x,y],
                 pixfound_isoval = (min(pf) < isovalue && isovalue < max(pf)),

--- a/isosurface.scad
+++ b/isosurface.scad
@@ -2580,7 +2580,7 @@ function mb_trapezoid(h,w,rounding=0,w1,w2, cutoff=INF, influence=1, negative=fa
 
 function _mb_stadium_full(dv, hl, r, cutoff, ex, neg) = let(
     dist = dv.y<-hl ? norm(dv-[0,-hl])
-      : dv.y<hl ? abs(dv.x) : norm(dv-[0,hl]),
+      : dv.y<hl ? abs(dv.x) : norm(dv-[0,hl])
 ) neg * mb_cutoff(dist, cutoff) * (r/dist)^ex;
 
 function mb_stadium(h, r, cutoff=INF, influence=1, negative=false, hide_debug=false, d,l,height,length) =

--- a/isosurface.scad
+++ b/isosurface.scad
@@ -3211,8 +3211,7 @@ module isosurface(f, isovalue, bounding_box, voxel_size, voxel_count=undef, reve
 }
 
 function isosurface(f, isovalue, bounding_box, voxel_size, voxel_count=undef, reverse=false, closed=true, exact_bounds=false, show_stats=false, _mball=false) =
-    assert(all_defined([f, bounding_box, isovalue]), "\nThe parameters f, bounding_box, and isovalue must all be defined.")
-    assert(is_num(bounding_box) || len(bounding_box[0])==2, "\nBounding box must be 2D.")
+    assert(all_defined([f, isovalue]), "\nThe parameters f and isovalue must both be defined.")
     assert(num_defined([voxel_size, voxel_count])<=1, "\nOnly one of voxel_size or voxel_count can be defined.")
     assert(is_undef(voxel_size) || (is_finite(voxel_size) && voxel_size>0) || (is_vector(voxel_size) && all_positive(voxel_size)), "\nvoxel_size must be a positive number, a 3-vector of positive values, or undef.")
     assert(is_list(isovalue) && len(isovalue)==2 && is_num(isovalue[0]) && is_num(isovalue[1]), "\nIsovalue must be a range; use [minvalue,INF] or [-INF,maxvalue] for an unbounded range.")
@@ -3419,7 +3418,7 @@ module contour(f, isovalue, bounding_box, pixel_size, pixel_count=undef, px_cent
 }
 
 function contour(f, isovalue, bounding_box, pixel_size, pixel_count=undef, px_centers=true, closed=true, exact_bounds=false, show_stats=false, anchor=CENTER, spin=0, _mball=false) =
-    assert(all_defined([f, isovalue, pixel_size]), "\nThe sparameters f, isovalue, and pixel_size must all be defined.")
+    assert(all_defined([f, isovalue]), "\nThe sparameters f and isovalue must both be defined.")
     assert(is_function(f) ||
         (is_list(f) &&
             // _mball=true allows pixel_size and bounding_box to coexist with f as array, because metaballs2d() already calculated them

--- a/isosurface.scad
+++ b/isosurface.scad
@@ -2891,7 +2891,7 @@ module metaballs2d(spec, bounding_box, pixel_size, pixel_count, isovalue=1, clos
         wid = 0.5 * (is_num(pixel_size) ? pixel_size : min(pixel_size));
         for(a=regionlist[1])
             color(a[0]==0 ? "gray" : a[0]>0 ? "#3399FF" : "#FF9933")
-                region(a[1], cp=cp, anchor=anchor, spin=spin, atype=atype);
+                region(a[1]);
         // display metaball as outline
         attachable(anchor, spin, two_d=true, region=regionlist[0]) {
             stroke(regionlist[0], width=wid, closed=true);
@@ -2899,7 +2899,7 @@ module metaballs2d(spec, bounding_box, pixel_size, pixel_count, isovalue=1, clos
         }
     } else { // debug==false, just display the metaball surface
         attachable(anchor, spin, two_d=true, region=regionlist) {
-            region(regionlist, cp=cp, anchor=anchor, spin=spin, atype=atype);
+            region(regionlist);
             children();
         }
     }


### PR DESCRIPTION
Isosurface.scad updates:
* Added contour() along with supporting functions and initializations.
* Added metaballs2d() along with supporting functions
* Added 2D metaball functions for circle, rect (squircle), trapezoid, stadium, connector2d, ring
* Included 2D metaball examples by adapting some of the existing 3D examples
* Included a couple of contour examples

Opening this PR as a draft for now.