### PR TITLE
dovetail big/small variable naming reversed (no-op)

### DIFF
--- a/joiners.scad
+++ b/joiners.scad
@@ -687,7 +687,7 @@ module dovetail(gender, width, height, slide, h, w, angle, slope, thickness, tap
 
     type = is_def(chamfer) && chamfer>0 ? "chamfer" : "circle";
 
-    smallend_half = round_corners(
+    bigend_half = round_corners(
         move(
             [0,-slide/2-extra,0],
             p=[
@@ -700,13 +700,13 @@ module dovetail(gender, width, height, slide, h, w, angle, slope, thickness, tap
         method=type, cut = fullsize, closed=false
     );
 
-    smallend_points = concat(select(smallend_half, 1, -2), [down(extra,p=select(smallend_half, -2))]);
+    bigend_points = concat(select(bigend_half, 1, -2), [down(extra,p=select(bigend_half, -2))]);
     offset = is_def(taper) ? -slide * tan(taper)
            : is_def(back_width) ? (back_width-width) / 2
            : 0;
-    bigend_points = move([offset+2*extra_offset,slide+2*extra,0], p=smallend_points);
+    smallend_points = move([offset+2*extra_offset,slide+2*extra,0], p=bigend_points);
 
-    bigenough = all_nonnegative(column(smallend_half,0)) && all_nonnegative(column(bigend_points,0));
+    bigenough = all_nonnegative(column(bigend_half,0)) && all_nonnegative(column(smallend_points,0));
 
     assert(bigenough, "Width (or back_width) of dovetail is not large enough for its geometry (angle and taper");
 
@@ -715,7 +715,7 @@ module dovetail(gender, width, height, slide, h, w, angle, slope, thickness, tap
 
     // This code computes the true normal from which the exact width factor can be obtained
     // as the x component.  Comparing to wfactor above shows that they agree.
-    //   pts = [smallend_points[0], smallend_points[1], bigend_points[1],bigend_points[0]];
+    //   pts = [bigend_points[0], bigend_points[1], smallend_points[1],smallend_points[0]];
     //   n = -polygon_normal(pts);
     //   echo(n=n);
     //   echo(invwfactor = 1/wfactor, error = n.x-1/wfactor);
@@ -726,8 +726,8 @@ module dovetail(gender, width, height, slide, h, w, angle, slope, thickness, tap
 
             skin(
                 [
-                    reverse(concat(smallend_points, xflip(p=reverse(smallend_points)))),
-                    reverse(concat(bigend_points, xflip(p=reverse(bigend_points))))
+                    reverse(concat(bigend_points, xflip(p=reverse(bigend_points)))),
+                    reverse(concat(smallend_points, xflip(p=reverse(smallend_points))))
                 ],
                 slices=0, convexity=4
             );


### PR DESCRIPTION
Writing a change I want to upstream, this confused me until I figured out the variables were named backwards. Just find/replace internal variables, no functionality change.

Testing:

Model was:
```
dovetail("male", width=25, h=10, slope=4, taper=2, slide=50,extra=0) position(BOT)
dovetail("female", width=25, h=10, slope=4, taper=2, slide=50, extra=1);
dovetail("male", w=25,h=10, back_width=8, slope=4, slide=40);
```

Added this code:

    `echo(bigend_points=bigend_points,smallend_points=smallend_points,offset=offset);` after line 709

before change:

```
ECHO: smallend_points = [[12.5, -25, 10], [10, -25, 0], [10, -25, 0]], bigend_points = [[10.754, 25, 10], [8.25396, 25, 0], [8.25396, 25, 0]], offset = -1.74604
ECHO: smallend_points = [[12.5349, -26, 10], [10.0349, -26, 0], [10.0349, -26, -1]], bigend_points = [[10.719, 26, 10], [8.21904, 26, 0], [8.21904, 26, -1]], offset = -1.74604
ECHO: smallend_points = [[12.5021, -20.01, 10], [10.0021, -20.01, 0], [10.0021, -20.01, -0.01]], bigend_points = [[3.99787, 20.01, 10], [1.49787, 20.01, 0], [1.49787, 20.01, -0.01]], offset = -8.5
```

after this change:

```
ECHO: bigend_points = [[12.5, -25, 10], [10, -25, 0], [10, -25, 0]], smallend_points = [[10.754, 25, 10], [8.25396, 25, 0], [8.25396, 25, 0]], offset = -1.74604
ECHO: bigend_points = [[12.5349, -26, 10], [10.0349, -26, 0], [10.0349, -26, -1]], smallend_points = [[10.719, 26, 10], [8.21904, 26, 0], [8.21904, 26, -1]], offset = -1.74604
ECHO: bigend_points = [[12.5021, -20.01, 10], [10.0021, -20.01, 0], [10.0021, -20.01, -0.01]], smallend_points = [[3.99787, 20.01, 10], [1.49787, 20.01, 0], [1.49787, 20.01, -0.01]], offset = -8.5
```