### PR TITLE
Add error message with solution to skin

### DIFF
--- a/skin.scad
+++ b/skin.scad
@@ -412,6 +412,8 @@ function skin(profiles, slices, refine=1, method="direct", sampling, caps, close
   assert(in_list(atype, _ANCHOR_TYPES), "\nAnchor type must be \"hull\" or \"intersect\".")
   assert(is_def(slices),"\nThe slices argument must be specified.")
   assert(is_list(profiles) && len(profiles)>1, "\nMust provide at least two profiles.")
+  // If the user forgets the first element should be a list, the other messages aren't as precisely helpful
+  assert(is_list(profiles)&&is_list(profiles[0])&&is_list(profiles[0][0]), "\nThe first argument to `skin` must be a list of paths")
   let(
        profiles = [for(p=profiles) if (is_region(p) && len(p)==1) p[0] else p]
   )

--- a/skin.scad
+++ b/skin.scad
@@ -413,7 +413,7 @@ function skin(profiles, slices, refine=1, method="direct", sampling, caps, close
   assert(is_def(slices),"\nThe slices argument must be specified.")
   assert(is_list(profiles) && len(profiles)>1, "\nMust provide at least two profiles.")
   // If the user forgets the first element should be a list, the other messages aren't as precisely helpful
-  assert(is_list(profiles)&&is_list(profiles[0])&&is_list(profiles[0][0]), "\nThe first argument to `skin` must be a list of paths")
+  assert(is_list(profiles)&&is_path(profiles[0]), "\nThe first argument to `skin` must be a list of paths")
   let(
        profiles = [for(p=profiles) if (is_region(p) && len(p)==1) p[0] else p]
   )


### PR DESCRIPTION
Maybe you're refactoring a bunch of nested arguments to skin and forget the first argument is supposed to be a list and you wasted an embarrassing amount of time figuring it out :) In this case, the error message changes from

Profiles [0, 1, 2, 3, 4, 5, 6, 7, 8] are not a paths or have length less than 3.

to

The first argument to `skin` must be a list of paths