### PR TITLE
Fixed octa spheroid() symmetry.

### DIFF
--- a/hinges.scad
+++ b/hinges.scad
@@ -458,7 +458,7 @@ module _knuckle_hinge_profile(offset, arm_height, arm_angle=45, knuckle_diam=4, 
         if (is_num(clear_top)) left(.1)fwd(clearance) rect([.1+clear_top, knuckle_diam+1+clearance], anchor=BOT+LEFT);
         if (is_def(clip)) fwd(clip) left(.1) rect([offset+knuckle_diam, ofs+round_bot+knuckle_diam+abs(clip)],anchor=BACK+LEFT);
       }
-      right(offset)ellipse(d=knuckle_diam,realign=true,circum=true);
+      right(offset)ellipse(d=knuckle_diam, circum=true);
     }
     if (is_num(pin_diam) && pin_diam>0){
       $fn = default(pin_fn,$fn);
@@ -466,7 +466,7 @@ module _knuckle_hinge_profile(offset, arm_height, arm_angle=45, knuckle_diam=4, 
         if (is_def(tearspin)){
           teardrop2d(d=pin_diam+2*get_slop(), realign=true, circum=true, spin=tearspin);
         }
-        else ellipse(d=pin_diam+2*get_slop(), realign=true, circum=true);
+        else ellipse(d=pin_diam+2*get_slop(), circum=true);
     }
   }
 } 

--- a/shapes2d.scad
+++ b/shapes2d.scad
@@ -1448,7 +1448,7 @@ function teardrop2d(r, ang=45, cap_h, d, circum=false, realign=false, anchor=CEN
                [
                  cap[0],
                  p,
-                 each select(fullcircle,i+1,-i-1-(realign?1:0)),
+                 each select(fullcircle,i+1,-i-1-(realign!=circum?1:0)),
                  xflip(p),
                  if(_extrapt || !pointycap) xflip(cap[0])
                ]

--- a/shapes2d.scad
+++ b/shapes2d.scad
@@ -432,16 +432,18 @@ module ellipse(r, d, realign=false, circum=false, uniform=false, anchor=CENTER, 
     attachable(anchor,spin, two_d=true, r=[rx,ry]) {
         if (uniform) {
             check = assert(!circum, "Circum option not allowed when \"uniform\" is true");
-            polygon(ellipse(r,realign=realign, circum=circum, uniform=true));
+            polygon(ellipse(r, realign=realign, circum=circum, uniform=true));
         }
         else if (rx < ry) {
             xscale(rx/ry) {
+                realign = circum? !realign : realign;
                 zrot(realign? 180/sides : 0) {
                     circle(r=ry, $fn=sides);
                 }
             }
         } else {
             yscale(ry/rx) {
+                realign = circum? !realign : realign;
                 zrot(realign? 180/sides : 0) {
                     circle(r=rx, $fn=sides);
                 }
@@ -504,7 +506,8 @@ function _ellipse_refine_realign(a,b,N, _theta=[],i=0) =
 function ellipse(r, d, realign=false, circum=false, uniform=false, anchor=CENTER, spin=0) =
     let(
         r = force_list(get_radius(r=r, d=d, dflt=1),2),
-        sides = segs(max(r))
+        sides = segs(max(r)),
+        realign = circum? !realign : realign
     )
     assert(all_positive(r), "All components of the radius must be positive.")
     uniform

--- a/skin.scad
+++ b/skin.scad
@@ -4359,7 +4359,7 @@ function texture(tex, n, border, gap, roughness, inset) =
         ) [
             [
                 each hex,
-                each move([0.5,0.5], p=yscale(sc, p=path3d(ellipse(d=1-2*border, circum=true, spin=-30,$fn=6),1))),
+                each move([0.5,0.5], p=yscale(sc, p=path3d(ellipse(d=1-2*border, circum=true, realign=true, spin=-30,$fn=6),1))),
                 hex[0]-[0,diag*sc,-1],
                 for (ang=[270+60,270-60]) hex[1]+yscale(sc, p=cylindrical_to_xyz(diag,ang,1)),
                 hex[2]-[0,diag*sc,-1],


### PR DESCRIPTION
The octagon style of spheroid() was malformed and asymmetrical due to the use of spherical_to_xyz().  This code fixes that.