### PR TITLE
Add Grip Fins to joiners

### DIFF
--- a/joiners.scad
+++ b/joiners.scad
@@ -1195,7 +1195,7 @@ module rabbit_clip(type, length, width,  snap, thickness, depth, compression=0.1
     snapmargin = -snap + last(sidepath).x;// - compression;
     if (is_pin){
       if (snapmargin<0) echo("WARNING: The snap is too large for the clip to squeeze to fit its socket")
-      echo(snapmargin=snapmargin);
+      //echo(snapmargin=snapmargin);
     }
     // Force tangent to be vertical at the outer edge of the clip to avoid overshoot
     fulltangent = list_set(path_tangents(fullpath, uniform=false),[2,8], [[0,1],[0,-1]]);
@@ -1454,7 +1454,7 @@ function _dist2inner_for_cylindrical_clamp(angle_from_tangent, or, ir) =
         length_from_tangent_circle_tangent_to_intersection_of_inner_circle = sqrt(pow(ir,2)-pow(tangent_circle_radius,2)),
         fin_length=length_from_starting_point_to_tangent_circle-length_from_tangent_circle_tangent_to_intersection_of_inner_circle
     )
-    echo(tangent_circle_radius=tangent_circle_radius,length_from_starting_point_to_tangent_circle=length_from_starting_point_to_tangent_circle,length_from_tangent_circle_tangent_to_intersection_of_inner_circle=length_from_tangent_circle_tangent_to_intersection_of_inner_circle,fin_length=fin_length)
+    //echo(tangent_circle_radius=tangent_circle_radius,length_from_starting_point_to_tangent_circle=length_from_starting_point_to_tangent_circle,length_from_tangent_circle_tangent_to_intersection_of_inner_circle=length_from_tangent_circle_tangent_to_intersection_of_inner_circle,fin_length=fin_length)
     fin_length;
 
 assert(_dist2inner_for_cylindrical_clamp(0,8,5)==3);
@@ -1503,7 +1503,7 @@ module cylindrical_clamp(h=1,od,id,od1,od2,id1,id2,or,ir,or1,or2,ir1,ir2,num=3,f
 //    fin_length1 = dist1;
 //    fin_length2 = _dist2inner_for_cylindrical_clamp(fin_angle, or2, ir2);
     actual_angle = (is_undef(fin_angle)?asin(ir1/or1):fin_angle)/*-asin(fin_thick/2/dist1)*/;
-    echo(fin_length1=fin_length1,actual_angle=actual_angle);
+    //echo(fin_length1=fin_length1,actual_angle=actual_angle);
     /*down(h/2)*/ skew(sxz=shift.x/h, syz=shift.y/h) /*up(h/2)*/
     // If sharing, this tag should probably be a uuid per invocation
 //    diff("circ_clamp") cylinder(h,r1=or1,r2=or2) {

--- a/joiners.scad
+++ b/joiners.scad
@@ -1483,10 +1483,10 @@ assert(_dist2inner_for_cylindrical_clamp(0,8,5)==3);
 //   fin_angle = Degrees away from the radius line (0 is straight in to center, 90 is tangent). If left unset, will pick the largest possible angle (which yields the longest possible fin). Default: undef
 //   $slop = Increase the inner radius by $slop.
 //   fin_thick = How thick the fin will be. Must be at least the minimum line width of your printer, but that often results in a single unstable wall. Better is to be at least 2xline width (for classic wall) or 1.75xline width (for Arachne). Default: 0.4
-//   TODO: document the rest
-// TODO: implement orient and anchor and attachables
-// TODO: allow other fin direction by expanding fin angle past 90
-module cylindrical_clamp(h=1,od=undef,id=undef,od1=undef,od2=undef,id1=undef,id2=undef,or=undef,ir=undef,or1=undef,or2=undef,ir1=undef,ir2=undef,num=3,fin_thick=0.4,fin_angle=undef,shift=[0,0]) {
+///  TODO: document the rest of the arguments
+/// TODO: implement orient and anchor and attachables
+/// TODO: allow other fin direction by expanding fin angle past 90
+module cylindrical_clamp(h=1,od,id,od1,od2,id1,id2,or,ir,or1,or2,ir1,ir2,num=3,fin_thick=0.4,fin_angle,shift=[0,0]) {
     //
     if(!is_undef(fin_angle)) {
         assert(fin_angle>0);

--- a/joiners.scad
+++ b/joiners.scad
@@ -1,4 +1,4 @@
-//////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
 // LibFile: joiners.scad
 //   Modules for joining separately printed parts including screw together, snap-together and dovetails.
 // Includes:
@@ -1194,8 +1194,9 @@ module rabbit_clip(type, length, width,  snap, thickness, depth, compression=0.1
 
     snapmargin = -snap + last(sidepath).x;// - compression;
     if (is_pin){
-      if (snapmargin<0) echo("WARNING: The snap is too large for the clip to squeeze to fit its socket")
-      //echo(snapmargin=snapmargin);
+      if (snapmargin<0)
+        echo("WARNING: The snap is too large for the clip to squeeze to fit its socket")
+          echo(snapmargin=snapmargin);
     }
     // Force tangent to be vertical at the outer edge of the clip to avoid overshoot
     fulltangent = list_set(path_tangents(fullpath, uniform=false),[2,8], [[0,1],[0,-1]]);


### PR DESCRIPTION
Grip fins allow a cylindrical object (or even ovoid-cross-section) to be held tightly, but also removable and reusable.

My searching didn't find anybody else having made these in SCAD. 

In [this old Slant 3D video](https://www.youtube.com/watch?v=yzg_NXM-NRs), he shows straight fins used. This is the one implemented so far.

In [this newer Slant 3D video](https://youtu.be/Bd7Yyn61XWQ?t=371) he uses a different shape of fin that I haven't implemented yet -- at one point I tried, but they don't work at small scale. Judging from the video it's theoretically as easy as taking the one I made and diffing it out.

This is the version I've used to make grip fins for holding PTFE tubes for my 3d printer. They aren't attachable yet and the docs aren't finished and the naming is dumb and the tests aren't in the right place, which is why it's draft.