### PR TITLE
Fix test_hex_drive_mask missing screw_drive.scad include

### DIFF
--- a/tests/test_screw_drive.scadtest
+++ b/tests/test_screw_drive.scadtest
@@ -98,6 +98,7 @@ test_phillips_diam();
 name = "test_hex_drive_mask"
 script = '''
 include <../std.scad>
+include <../screw_drive.scad>
 
 module test_hex_drive_mask() {
     hex_drive_mask(size=3, length=5);


### PR DESCRIPTION
## Summary

- The `test_hex_drive_mask` test in `tests/test_screw_drive.scadtest` was failing because it was missing `include <../screw_drive.scad>`, causing OpenSCAD to report `hex_drive_mask` as an unknown module.

## Test plan

- [x] `./scripts/run_tests.sh tests/test_screw_drive.scadtest` — all 6 tests pass