### PR TITLE
test: add edge case coverage for transform and vector functions (#231)

### DIFF
--- a/tests/test_transforms.scadtest
+++ b/tests/test_transforms.scadtest
@@ -9,6 +9,20 @@ module test_translate() {
         assert_equal(translate(val), [[1,0,0,val.x],[0,1,0,val.y],[0,0,1,val.z],[0,0,0,1]]);
         assert_equal(translate(val, p=[1,2,3]), [1,2,3]+val);
     }
+    // Traducao 2D: vetor de 2 elementos
+    assert_equal(translate([4,5]), [[1,0,0,4],[0,1,0,5],[0,0,1,0],[0,0,0,1]]);
+    assert_equal(translate([4,5], p=[1,2,3]), [5,7,3]);
+    assert_equal(translate([0,0], p=[1,2,3]), [1,2,3]);
+    // Traducao 2D ponto 2D
+    assert_equal(translate([3,4], p=[10,20]), [13,24]);
+    // Traducao com valores negativos grandes
+    assert_equal(translate([-100,-200,-300], p=[1,2,3]), [-99,-198,-297]);
+    // Traducao eixo unico
+    assert_equal(translate([5,0,0], p=[0,0,0]), [5,0,0]);
+    assert_equal(translate([0,5,0], p=[0,0,0]), [0,5,0]);
+    assert_equal(translate([0,0,5], p=[0,0,0]), [0,0,5]);
+    // Lista de pontos
+    assert_equal(translate([1,2,3], p=[[0,0,0],[10,10,10]]), [[1,2,3],[11,12,13]]);
     // Verify that module at least doesn't crash.
     translate([-5,-5,-5]) translate([0,0,0]) translate([5,5,5]) union(){};
 }
@@ -33,6 +47,18 @@ module test_move() {
     assert_equal(move("centroid", sq), move(-centroid(sq),sq));
     assert_equal(move("mean", vals), move(-mean(vals), vals));
     assert_equal(move("box", vals), move(-mean(pointlist_bounds(vals)),vals));
+    // Movimento 2D: vetor de 2 elementos
+    assert_equal(move([4,5]), [[1,0,0,4],[0,1,0,5],[0,0,1,0],[0,0,0,1]]);
+    assert_equal(move([4,5], p=[1,2,3]), [5,7,3]);
+    assert_equal(move([0,0], p=[7,8,9]), [7,8,9]);
+    // Ponto 2D com vetor 2D
+    assert_equal(move([3,4], p=[10,20]), [13,24]);
+    // Lista de pontos
+    assert_equal(move([1,1,1], p=[[0,0,0],[5,5,5]]), [[1,1,1],[6,6,6]]);
+    // Valores negativos grandes
+    assert_equal(move([-1000,2000,-3000], p=[1,2,3]), [-999,2002,-2997]);
+    // Composicao: move(a) * move(b) = move(a+b)
+    assert_approx(move([1,2,3]) * move([4,5,6]), move([5,7,9]));
 }
 test_move();
 '''
@@ -168,6 +194,23 @@ module test_scale() {
     assert_equal(scale([2,2], cp=[0.5,0.5], p=square(1)), move([-0.5,-0.5], p=square([2,2])));
     assert_equal(scale([2,3,4], p=cb), cube([2,3,4]));
     assert_equal(scale([-2,-3,-4], p=cb), [[for (p=cb[0]) v_mul(p,[-2,-3,-4])], [for (f=cb[1]) reverse(f)]]);
+    // Escala uniforme 1 = identidade
+    assert_equal(scale(1), [[1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1]]);
+    assert_equal(scale(1, p=[7,8,9]), [7,8,9]);
+    assert_equal(scale([1,1,1]), [[1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1]]);
+    assert_equal(scale([1,1,1], p=[7,8,9]), [7,8,9]);
+    // Escala zero
+    assert_equal(scale(0, p=[5,10,15]), [0,0,0]);
+    assert_equal(scale([0,0,0], p=[5,10,15]), [0,0,0]);
+    // Escala negativa uniforme
+    assert_equal(scale(-1, p=[3,4,5]), [-3,-4,-5]);
+    // Escala com lista de pontos
+    assert_equal(scale(2, p=[[1,0,0],[0,1,0]]), [[2,0,0],[0,2,0]]);
+    assert_equal(scale([2,3,4], p=[[1,1,1],[2,2,2]]), [[2,3,4],[4,6,8]]);
+    // Escala 2D
+    assert_equal(scale([2,3], p=[[1,1],[2,2]]), [[2,3],[4,6]]);
+    // Composicao: scale(a) * scale(a) = scale(a^2) para uniforme
+    assert_approx(scale(3) * scale(3), scale(9));
     // Verify that module at least doesn't crash.
     scale(-5) scale(5) union(){};
 }
@@ -251,6 +294,23 @@ module test_mirror() {
         // Verify that module at least doesn't crash.
         mirror(val) union(){};
     }
+    // Espelho duplo = identidade
+    assert_approx(mirror([1,0,0]) * mirror([1,0,0]), affine3d_identity(), "double mirror X = identity");
+    assert_approx(mirror([0,1,0]) * mirror([0,1,0]), affine3d_identity(), "double mirror Y = identity");
+    assert_approx(mirror([0,0,1]) * mirror([0,0,1]), affine3d_identity(), "double mirror Z = identity");
+    // Espelho com vetor diagonal
+    assert_approx(mirror([1,1,0]) * mirror([1,1,0]), affine3d_identity(), "double mirror diagonal = identity");
+    // Espelho com ponto na origem: permanece na origem
+    assert_approx(mirror([1,0,0], p=[0,0,0]), [0,0,0], "mirror origin stays at origin");
+    // Espelho em eixo X inverte apenas X
+    assert_approx(mirror([1,0,0], p=[5,7,9]), [-5,7,9], "mirror X axis");
+    assert_approx(mirror([0,1,0], p=[5,7,9]), [5,-7,9], "mirror Y axis");
+    assert_approx(mirror([0,0,1], p=[5,7,9]), [5,7,-9], "mirror Z axis");
+    // Espelho com lista de pontos
+    assert_approx(mirror([1,0,0], p=[[1,2,3],[4,5,6]]), [[-1,2,3],[-4,5,6]], "mirror point list");
+    // Vetor nao unitario: deve funcionar igual (normalizacao interna)
+    assert_approx(mirror([2,0,0], p=[5,7,9]), [-5,7,9], "mirror non-unit vector");
+    assert_approx(mirror([0,10,0], p=[5,7,9]), [5,-7,9], "mirror scaled vector");
 }
 test_mirror();
 '''
@@ -263,6 +323,18 @@ include <../std.scad>
 module test_xflip() {
     assert_approx(xflip(), [[-1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1]]);
     assert_approx(xflip(p=[1,2,3]), [-1,2,3]);
+    // Valor zero permanece zero
+    assert_approx(xflip(p=[0,5,10]), [0,5,10]);
+    // Valores negativos
+    assert_approx(xflip(p=[-3,2,1]), [3,2,1]);
+    // Duplo flip = identidade
+    assert_approx(xflip() * xflip(), affine3d_identity(), "double xflip = identity");
+    // Flip com offset
+    assert_approx(xflip(x=5, p=[5,2,3]), [5,2,3], "xflip at x=5, point on plane");
+    assert_approx(xflip(x=5, p=[7,2,3]), [3,2,3], "xflip at x=5, point off plane");
+    assert_approx(xflip(x=5, p=[0,0,0]), [10,0,0], "xflip at x=5, origin");
+    // Lista de pontos
+    assert_approx(xflip(p=[[1,2,3],[4,5,6]]), [[-1,2,3],[-4,5,6]]);
     // Verify that module at least doesn't crash.
     xflip() union(){};
 }
@@ -277,6 +349,18 @@ include <../std.scad>
 module test_yflip() {
     assert_approx(yflip(), [[1,0,0,0],[0,-1,0,0],[0,0,1,0],[0,0,0,1]]);
     assert_approx(yflip(p=[1,2,3]), [1,-2,3]);
+    // Valor zero permanece zero
+    assert_approx(yflip(p=[5,0,10]), [5,0,10]);
+    // Valores negativos
+    assert_approx(yflip(p=[1,-3,2]), [1,3,2]);
+    // Duplo flip = identidade
+    assert_approx(yflip() * yflip(), affine3d_identity(), "double yflip = identity");
+    // Flip com offset
+    assert_approx(yflip(y=5, p=[2,5,3]), [2,5,3], "yflip at y=5, point on plane");
+    assert_approx(yflip(y=5, p=[2,7,3]), [2,3,3], "yflip at y=5, point off plane");
+    assert_approx(yflip(y=5, p=[0,0,0]), [0,10,0], "yflip at y=5, origin");
+    // Lista de pontos
+    assert_approx(yflip(p=[[1,2,3],[4,5,6]]), [[1,-2,3],[4,-5,6]]);
     // Verify that module at least doesn't crash.
     yflip() union(){};
 }
@@ -291,6 +375,18 @@ include <../std.scad>
 module test_zflip() {
     assert_approx(zflip(), [[1,0,0,0],[0,1,0,0],[0,0,-1,0],[0,0,0,1]]);
     assert_approx(zflip(p=[1,2,3]), [1,2,-3]);
+    // Valor zero permanece zero
+    assert_approx(zflip(p=[5,10,0]), [5,10,0]);
+    // Valores negativos
+    assert_approx(zflip(p=[1,2,-3]), [1,2,3]);
+    // Duplo flip = identidade
+    assert_approx(zflip() * zflip(), affine3d_identity(), "double zflip = identity");
+    // Flip com offset
+    assert_approx(zflip(z=5, p=[2,3,5]), [2,3,5], "zflip at z=5, point on plane");
+    assert_approx(zflip(z=5, p=[2,3,7]), [2,3,3], "zflip at z=5, point off plane");
+    assert_approx(zflip(z=5, p=[0,0,0]), [0,0,10], "zflip at z=5, origin");
+    // Lista de pontos
+    assert_approx(zflip(p=[[1,2,3],[4,5,6]]), [[1,2,-3],[4,5,-6]]);
     // Verify that module at least doesn't crash.
     zflip() union(){};
 }
@@ -483,6 +579,10 @@ include <../std.scad>
 module test_frame_map() {
     assert(approx(frame_map(x=[1,1,0], y=[-1,1,0]), affine3d_zrot(45)));
     assert(approx(frame_map(x=[0,1,0], y=[0,0,1]), rot(v=[1,1,1],a=120)));
+    // Identidade: eixos padrao
+    assert_approx(frame_map(x=[1,0,0], y=[0,1,0]), affine3d_identity(), "frame_map identity");
+    // Trocar X e Y equivale a rotacao de 90 em Z com flip
+    assert_approx(frame_map(x=[0,1,0], y=[-1,0,0]), affine3d_zrot(90), "frame_map 90 deg Z");
 }
 test_frame_map();
 '''
@@ -496,6 +596,26 @@ module test_skew() {
     m = affine3d_skew(sxy=2, sxz=3, syx=4, syz=5, szx=6, szy=7);
     assert_approx(skew(sxy=2, sxz=3, syx=4, syz=5, szx=6, szy=7), m);
     assert_approx(skew(sxy=2, sxz=3, syx=4, syz=5, szx=6, szy=7, p=[1,2,3]), apply(m,[1,2,3]));
+    // Skew zero = identidade
+    assert_approx(skew(), affine3d_identity(), "skew with no args = identity");
+    assert_approx(skew(sxy=0, sxz=0, syx=0, syz=0, szx=0, szy=0), affine3d_identity(), "skew all zeros = identity");
+    // Skew zero aplicado a ponto nao altera
+    assert_approx(skew(p=[5,10,15]), [5,10,15], "skew zero on point = identity");
+    // Skew de eixo individual
+    assert_approx(skew(sxy=1, p=[1,2,3]), apply(affine3d_skew(sxy=1), [1,2,3]), "skew sxy only");
+    assert_approx(skew(sxz=1, p=[1,2,3]), apply(affine3d_skew(sxz=1), [1,2,3]), "skew sxz only");
+    assert_approx(skew(syx=1, p=[1,2,3]), apply(affine3d_skew(syx=1), [1,2,3]), "skew syx only");
+    assert_approx(skew(syz=1, p=[1,2,3]), apply(affine3d_skew(syz=1), [1,2,3]), "skew syz only");
+    assert_approx(skew(szx=1, p=[1,2,3]), apply(affine3d_skew(szx=1), [1,2,3]), "skew szx only");
+    assert_approx(skew(szy=1, p=[1,2,3]), apply(affine3d_skew(szy=1), [1,2,3]), "skew szy only");
+    // Skew com valores negativos
+    assert_approx(skew(sxy=-3, p=[1,2,3]), apply(affine3d_skew(sxy=-3), [1,2,3]), "skew negative sxy");
+    // Skew via angulo
+    assert_approx(skew(axy=45, p=[1,2,3]), skew(sxy=tan(45), p=[1,2,3]), "skew axy=45 == sxy=tan(45)");
+    assert_approx(skew(ayx=30, p=[1,2,3]), skew(syx=tan(30), p=[1,2,3]), "skew ayx=30 == syx=tan(30)");
+    // Lista de pontos
+    m2 = affine3d_skew(sxy=2);
+    assert_approx(skew(sxy=2, p=[[1,0,0],[0,1,0],[0,0,1]]), apply(m2, [[1,0,0],[0,1,0],[0,0,1]]), "skew point list");
     // Verify that module at least doesn't crash.
     skew(undef,2,3,4,5,6,7) union(){};
 }

--- a/tests/test_vectors.scadtest
+++ b/tests/test_vectors.scadtest
@@ -44,6 +44,21 @@ include <../std.scad>
 module test_v_floor() {
     assert_equal(v_floor([2.0, 3.14, 18.9, 7]), [2,3,18,7]);
     assert_equal(v_floor([-2.0, -3.14, -18.9, -7]), [-2,-4,-19,-7]);
+    // Vetor zero
+    assert_equal(v_floor([0, 0, 0]), [0, 0, 0]);
+    assert_equal(v_floor([0.0, 0.0]), [0, 0]);
+    // Valores inteiros (sem mudanca)
+    assert_equal(v_floor([1, -1, 5, -5]), [1, -1, 5, -5]);
+    // Valores proximos de inteiros
+    assert_equal(v_floor([0.999, -0.001]), [0, -1]);
+    assert_equal(v_floor([1.001, -1.999]), [1, -2]);
+    // Vetor 2D
+    assert_equal(v_floor([3.7, -2.3]), [3, -3]);
+    // Valores grandes
+    assert_equal(v_floor([99999.9, -99999.1]), [99999, -100000]);
+    // Vetor unitario com componentes fracionarios
+    assert_equal(v_floor([0.5, 0.5, 0.5]), [0, 0, 0]);
+    assert_equal(v_floor([-0.5, -0.5, -0.5]), [-1, -1, -1]);
 }
 test_v_floor();
 '''
@@ -56,6 +71,21 @@ include <../std.scad>
 module test_v_ceil() {
     assert_equal(v_ceil([2.0, 3.14, 18.9, 7]), [2,4,19,7]);
     assert_equal(v_ceil([-2.0, -3.14, -18.9, -7]), [-2,-3,-18,-7]);
+    // Vetor zero
+    assert_equal(v_ceil([0, 0, 0]), [0, 0, 0]);
+    assert_equal(v_ceil([0.0, 0.0]), [0, 0]);
+    // Valores inteiros (sem mudanca)
+    assert_equal(v_ceil([1, -1, 5, -5]), [1, -1, 5, -5]);
+    // Valores proximos de inteiros
+    assert_equal(v_ceil([0.001, -0.999]), [1, 0]);
+    assert_equal(v_ceil([1.001, -1.999]), [2, -1]);
+    // Vetor 2D
+    assert_equal(v_ceil([3.2, -2.7]), [4, -2]);
+    // Valores grandes
+    assert_equal(v_ceil([99999.1, -99999.9]), [100000, -99999]);
+    // Vetor unitario com componentes fracionarios
+    assert_equal(v_ceil([0.5, 0.5, 0.5]), [1, 1, 1]);
+    assert_equal(v_ceil([-0.5, -0.5, -0.5]), [0, 0, 0]);
 }
 test_v_ceil();
 '''
@@ -91,6 +121,20 @@ module test_v_mul() {
     assert_equal(v_mul([3,4,5], [8,7,6]), [24,28,30]);
     assert_equal(v_mul([1,2,3], [4,5,6]), [4,10,18]);
     assert_equal(v_mul([[1,2,3],[4,5,6],[7,8,9]], [[4,5,6],[3,2,1],[5,9,3]]), [32,28,134]);
+    // Multiplicacao por vetor zero
+    assert_equal(v_mul([1,2,3], [0,0,0]), [0,0,0]);
+    assert_equal(v_mul([0,0,0], [5,6,7]), [0,0,0]);
+    // Valores negativos
+    assert_equal(v_mul([-1,-2,-3], [4,5,6]), [-4,-10,-18]);
+    assert_equal(v_mul([-1,-2], [-3,-4]), [3,8]);
+    // Vetor unitario (identidade)
+    assert_equal(v_mul([5,10,15], [1,1,1]), [5,10,15]);
+    // Valores grandes
+    assert_equal(v_mul([1000,2000], [3000,4000]), [3000000,8000000]);
+    // Vetor 2D
+    assert_equal(v_mul([3,4], [5,6]), [15,24]);
+    // Multiplicacao com valores fracionarios
+    assert_approx(v_mul([0.5, 0.25], [2, 4]), [1, 1]);
 }
 test_v_mul();
 '''
@@ -102,6 +146,22 @@ include <../std.scad>
 
 module test_v_div() {
     assert(v_div([24,28,30], [8,7,6]) == [3, 4, 5]);
+    // Divisao com valores negativos
+    assert_equal(v_div([-24,28,-30], [8,-7,6]), [-3,-4,-5]);
+    assert_equal(v_div([-10,-20], [-2,-5]), [5,4]);
+    // Divisao de zero por nao-zero
+    assert_equal(v_div([0,0,0], [1,2,3]), [0,0,0]);
+    // Vetor unitario como divisor (identidade)
+    assert_equal(v_div([5,10,15], [1,1,1]), [5,10,15]);
+    // Valores grandes
+    assert_equal(v_div([9000000,8000000], [3000,4000]), [3000,2000]);
+    // Vetor 2D
+    assert_equal(v_div([10,20], [2,5]), [5,4]);
+    // Divisao com resultado fracionario
+    assert_approx(v_div([1,1,1], [3,3,3]), [1/3, 1/3, 1/3]);
+    assert_approx(v_div([1,2], [4,8]), [0.25, 0.25]);
+    // Dividir por si mesmo
+    assert_approx(v_div([7,13,29], [7,13,29]), [1,1,1]);
 }
 test_v_div();
 '''
@@ -117,6 +177,22 @@ module test_v_abs() {
     assert(v_abs([-2,4,8]) == [2,4,8]);
     assert(v_abs([2,-4,8]) == [2,4,8]);
     assert(v_abs([2,4,-8]) == [2,4,8]);
+    // Vetor zero
+    assert(v_abs([0,0,0]) == [0,0,0]);
+    assert(v_abs([0,0]) == [0,0]);
+    // Vetor 2D
+    assert(v_abs([-3,4]) == [3,4]);
+    assert(v_abs([3,-4]) == [3,4]);
+    // Valores unitarios
+    assert(v_abs([1,0,0]) == [1,0,0]);
+    assert(v_abs([-1,0,0]) == [1,0,0]);
+    assert(v_abs([0,-1,0]) == [0,1,0]);
+    // Valores grandes
+    assert(v_abs([-100000, 100000, -99999]) == [100000, 100000, 99999]);
+    // Valores fracionarios
+    assert_approx(v_abs([-0.5, 0.25, -0.125]), [0.5, 0.25, 0.125]);
+    // Vetor longo
+    assert(v_abs([-1,-2,-3,-4,-5]) == [1,2,3,4,5]);
 }
 test_v_abs();
 '''
@@ -147,6 +223,25 @@ module test_v_theta() {
     assert_approx(v_theta([0,1,1]), 90);
     assert_approx(v_theta([0,-1,1]), -90);
     assert_approx(v_theta([1,1,1]), 45);
+    // Vetores unitarios nos eixos com magnitude variada
+    assert_approx(v_theta([100,0]), 0);
+    assert_approx(v_theta([0,100]), 90);
+    assert_approx(v_theta([-100,0]), 180);
+    assert_approx(v_theta([0,-100]), -90);
+    // Angulos em 2D com valores negativos
+    assert_approx(v_theta([-1,-1]), -135);
+    assert_approx(v_theta([1,-1]), -45);
+    // Valores grandes em 3D
+    assert_approx(v_theta([1000, 1000, 0]), 45);
+    assert_approx(v_theta([-1000, 1000, 500]), 135);
+    // Vetores com componente Z grande (Z nao afeta theta)
+    assert_approx(v_theta([1, 0, 99999]), 0);
+    assert_approx(v_theta([0, 1, -99999]), 90);
+    // Angulos de 30, 60 graus em 2D
+    assert_approx(v_theta([cos(30), sin(30)]), 30);
+    assert_approx(v_theta([cos(60), sin(60)]), 60);
+    assert_approx(v_theta([cos(-60), sin(-60)]), -60);
+    assert_approx(v_theta([cos(150), sin(150)]), 150);
 }
 test_v_theta();
 '''
@@ -206,6 +301,30 @@ module test_unit() {
     assert(abs(norm(unit([-10,0,0]))-1) < _EPSILON);
     assert(abs(norm(unit([0,-10,0]))-1) < _EPSILON);
     assert(abs(norm(unit([0,0,-10]))-1) < _EPSILON);
+    // Vetores negativos nos eixos
+    assert_approx(unit([-10,0,0]), [-1,0,0]);
+    assert_approx(unit([0,-10,0]), [0,-1,0]);
+    assert_approx(unit([0,0,-10]), [0,0,-1]);
+    // Vetores ja unitarios (devem retornar o mesmo)
+    assert_approx(unit([1,0,0]), [1,0,0]);
+    assert_approx(unit([0,1,0]), [0,1,0]);
+    assert_approx(unit([0,0,1]), [0,0,1]);
+    // Vetor 2D
+    assert_approx(unit([3,4]), [0.6, 0.8]);
+    assert_approx(unit([-3,4]), [-0.6, 0.8]);
+    assert(abs(norm(unit([3,4]))-1) < _EPSILON);
+    // Valores grandes
+    assert(abs(norm(unit([100000,0,0]))-1) < _EPSILON);
+    assert_approx(unit([100000,0,0]), [1,0,0]);
+    // Valores pequenos (mas nao zero)
+    assert(abs(norm(unit([0.001, 0, 0]))-1) < _EPSILON);
+    assert_approx(unit([0.001, 0, 0]), [1, 0, 0]);
+    // Direcao preservada para vetores diagonais
+    assert_approx(unit([1,1,0]), [1/sqrt(2), 1/sqrt(2), 0]);
+    assert_approx(unit([1,1,1]), [1/sqrt(3), 1/sqrt(3), 1/sqrt(3)]);
+    // Parametro error para vetor zero
+    assert_equal(unit([0,0,0], error=[0,0,0]), [0,0,0]);
+    assert_equal(unit([0,0,0], error=[1,2,3]), [1,2,3]);
 }
 test_unit();
 '''
@@ -331,6 +450,20 @@ include <../std.scad>
 
 module test_add_scalar() {
     assert(add_scalar([1,2,3],3) == [4,5,6]);
+    // Somar zero (identidade)
+    assert(add_scalar([1,2,3],0) == [1,2,3]);
+    // Somar valor negativo
+    assert(add_scalar([1,2,3],-3) == [-2,-1,0]);
+    // Vetor zero
+    assert(add_scalar([0,0,0],5) == [5,5,5]);
+    // Vetor 2D
+    assert(add_scalar([10,20],5) == [15,25]);
+    // Valores negativos no vetor
+    assert(add_scalar([-1,-2,-3],3) == [2,1,0]);
+    // Valores grandes
+    assert(add_scalar([100000,200000],1) == [100001,200001]);
+    // Valores fracionarios
+    assert_approx(add_scalar([0.1, 0.2, 0.3], 0.5), [0.6, 0.7, 0.8]);
 }
 test_add_scalar();
 '''

--- a/tests/test_vectors.scadtest
+++ b/tests/test_vectors.scadtest
@@ -44,19 +44,19 @@ include <../std.scad>
 module test_v_floor() {
     assert_equal(v_floor([2.0, 3.14, 18.9, 7]), [2,3,18,7]);
     assert_equal(v_floor([-2.0, -3.14, -18.9, -7]), [-2,-4,-19,-7]);
-    // Vetor zero
+    // Zero vector
     assert_equal(v_floor([0, 0, 0]), [0, 0, 0]);
     assert_equal(v_floor([0.0, 0.0]), [0, 0]);
-    // Valores inteiros (sem mudanca)
+    // Integer values (unchanged)
     assert_equal(v_floor([1, -1, 5, -5]), [1, -1, 5, -5]);
-    // Valores proximos de inteiros
+    // Values close to integers
     assert_equal(v_floor([0.999, -0.001]), [0, -1]);
     assert_equal(v_floor([1.001, -1.999]), [1, -2]);
-    // Vetor 2D
+    // 2D vector
     assert_equal(v_floor([3.7, -2.3]), [3, -3]);
-    // Valores grandes
+    // Large values
     assert_equal(v_floor([99999.9, -99999.1]), [99999, -100000]);
-    // Vetor unitario com componentes fracionarios
+    // Unit vector with fractional components
     assert_equal(v_floor([0.5, 0.5, 0.5]), [0, 0, 0]);
     assert_equal(v_floor([-0.5, -0.5, -0.5]), [-1, -1, -1]);
 }


### PR DESCRIPTION
## Summary
- Add ~74 new asserts across 9 transform test functions (translate, move, scale, mirror, xflip, yflip, zflip, skew, frame_map)
- Add ~80 new asserts across 8 vector test functions (unit, v_abs, v_floor, v_ceil, v_mul, v_div, v_theta, add_scalar)
- Covers edge cases: zero vectors, negative values, identity transforms, 2D/3D variants

## Test plan
- [x] All new asserts pass in OpenSCAD
- [x] No ECHO output produced
- [x] No regressions in existing tests

Addresses #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)