### PR TITLE
Translate Portuguese comments to English in test files

### DIFF
--- a/tests/test_transforms.scadtest
+++ b/tests/test_transforms.scadtest
@@ -9,19 +9,19 @@ module test_translate() {
         assert_equal(translate(val), [[1,0,0,val.x],[0,1,0,val.y],[0,0,1,val.z],[0,0,0,1]]);
         assert_equal(translate(val, p=[1,2,3]), [1,2,3]+val);
     }
-    // Traducao 2D: vetor de 2 elementos
+    // 2D translation: 2-element vector
     assert_equal(translate([4,5]), [[1,0,0,4],[0,1,0,5],[0,0,1,0],[0,0,0,1]]);
     assert_equal(translate([4,5], p=[1,2,3]), [5,7,3]);
     assert_equal(translate([0,0], p=[1,2,3]), [1,2,3]);
-    // Traducao 2D ponto 2D
+    // 2D translation with 2D point
     assert_equal(translate([3,4], p=[10,20]), [13,24]);
-    // Traducao com valores negativos grandes
+    // Translation with large negative values
     assert_equal(translate([-100,-200,-300], p=[1,2,3]), [-99,-198,-297]);
-    // Traducao eixo unico
+    // Single-axis translation
     assert_equal(translate([5,0,0], p=[0,0,0]), [5,0,0]);
     assert_equal(translate([0,5,0], p=[0,0,0]), [0,5,0]);
     assert_equal(translate([0,0,5], p=[0,0,0]), [0,0,5]);
-    // Lista de pontos
+    // List of points
     assert_equal(translate([1,2,3], p=[[0,0,0],[10,10,10]]), [[1,2,3],[11,12,13]]);
     // Verify that module at least doesn't crash.
     translate([-5,-5,-5]) translate([0,0,0]) translate([5,5,5]) union(){};
@@ -47,17 +47,17 @@ module test_move() {
     assert_equal(move("centroid", sq), move(-centroid(sq),sq));
     assert_equal(move("mean", vals), move(-mean(vals), vals));
     assert_equal(move("box", vals), move(-mean(pointlist_bounds(vals)),vals));
-    // Movimento 2D: vetor de 2 elementos
+    // 2D move: 2-element vector
     assert_equal(move([4,5]), [[1,0,0,4],[0,1,0,5],[0,0,1,0],[0,0,0,1]]);
     assert_equal(move([4,5], p=[1,2,3]), [5,7,3]);
     assert_equal(move([0,0], p=[7,8,9]), [7,8,9]);
-    // Ponto 2D com vetor 2D
+    // 2D point with 2D vector
     assert_equal(move([3,4], p=[10,20]), [13,24]);
-    // Lista de pontos
+    // List of points
     assert_equal(move([1,1,1], p=[[0,0,0],[5,5,5]]), [[1,1,1],[6,6,6]]);
-    // Valores negativos grandes
+    // Large negative values
     assert_equal(move([-1000,2000,-3000], p=[1,2,3]), [-999,2002,-2997]);
-    // Composicao: move(a) * move(b) = move(a+b)
+    // Composition: move(a) * move(b) = move(a+b)
     assert_approx(move([1,2,3]) * move([4,5,6]), move([5,7,9]));
 }
 test_move();
@@ -194,22 +194,22 @@ module test_scale() {
     assert_equal(scale([2,2], cp=[0.5,0.5], p=square(1)), move([-0.5,-0.5], p=square([2,2])));
     assert_equal(scale([2,3,4], p=cb), cube([2,3,4]));
     assert_equal(scale([-2,-3,-4], p=cb), [[for (p=cb[0]) v_mul(p,[-2,-3,-4])], [for (f=cb[1]) reverse(f)]]);
-    // Escala uniforme 1 = identidade
+    // Uniform scale 1 = identity
     assert_equal(scale(1), [[1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1]]);
     assert_equal(scale(1, p=[7,8,9]), [7,8,9]);
     assert_equal(scale([1,1,1]), [[1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1]]);
     assert_equal(scale([1,1,1], p=[7,8,9]), [7,8,9]);
-    // Escala zero
+    // Zero scale
     assert_equal(scale(0, p=[5,10,15]), [0,0,0]);
     assert_equal(scale([0,0,0], p=[5,10,15]), [0,0,0]);
-    // Escala negativa uniforme
+    // Uniform negative scale
     assert_equal(scale(-1, p=[3,4,5]), [-3,-4,-5]);
-    // Escala com lista de pontos
+    // Scale with list of points
     assert_equal(scale(2, p=[[1,0,0],[0,1,0]]), [[2,0,0],[0,2,0]]);
     assert_equal(scale([2,3,4], p=[[1,1,1],[2,2,2]]), [[2,3,4],[4,6,8]]);
-    // Escala 2D
+    // 2D scale
     assert_equal(scale([2,3], p=[[1,1],[2,2]]), [[2,3],[4,6]]);
-    // Composicao: scale(a) * scale(a) = scale(a^2) para uniforme
+    // Composition: scale(a) * scale(a) = scale(a^2) for uniform scale
     assert_approx(scale(3) * scale(3), scale(9));
     // Verify that module at least doesn't crash.
     scale(-5) scale(5) union(){};
@@ -294,21 +294,21 @@ module test_mirror() {
         // Verify that module at least doesn't crash.
         mirror(val) union(){};
     }
-    // Espelho duplo = identidade
+    // Double mirror = identity
     assert_approx(mirror([1,0,0]) * mirror([1,0,0]), affine3d_identity(), "double mirror X = identity");
     assert_approx(mirror([0,1,0]) * mirror([0,1,0]), affine3d_identity(), "double mirror Y = identity");
     assert_approx(mirror([0,0,1]) * mirror([0,0,1]), affine3d_identity(), "double mirror Z = identity");
-    // Espelho com vetor diagonal
+    // Mirror with diagonal vector
     assert_approx(mirror([1,1,0]) * mirror([1,1,0]), affine3d_identity(), "double mirror diagonal = identity");
-    // Espelho com ponto na origem: permanece na origem
+    // Mirror with point at origin: stays at origin
     assert_approx(mirror([1,0,0], p=[0,0,0]), [0,0,0], "mirror origin stays at origin");
-    // Espelho em eixo X inverte apenas X
+    // Mirroring on each axis inverts only that axis component
     assert_approx(mirror([1,0,0], p=[5,7,9]), [-5,7,9], "mirror X axis");
     assert_approx(mirror([0,1,0], p=[5,7,9]), [5,-7,9], "mirror Y axis");
     assert_approx(mirror([0,0,1], p=[5,7,9]), [5,7,-9], "mirror Z axis");
-    // Espelho com lista de pontos
+    // Mirror with list of points
     assert_approx(mirror([1,0,0], p=[[1,2,3],[4,5,6]]), [[-1,2,3],[-4,5,6]], "mirror point list");
-    // Vetor nao unitario: deve funcionar igual (normalizacao interna)
+    // Non-unit vector: should work the same (internally normalized)
     assert_approx(mirror([2,0,0], p=[5,7,9]), [-5,7,9], "mirror non-unit vector");
     assert_approx(mirror([0,10,0], p=[5,7,9]), [5,-7,9], "mirror scaled vector");
 }
@@ -323,17 +323,17 @@ include <../std.scad>
 module test_xflip() {
     assert_approx(xflip(), [[-1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1]]);
     assert_approx(xflip(p=[1,2,3]), [-1,2,3]);
-    // Valor zero permanece zero
+    // Zero value stays zero
     assert_approx(xflip(p=[0,5,10]), [0,5,10]);
-    // Valores negativos
+    // Negative values
     assert_approx(xflip(p=[-3,2,1]), [3,2,1]);
-    // Duplo flip = identidade
+    // Double flip = identity
     assert_approx(xflip() * xflip(), affine3d_identity(), "double xflip = identity");
-    // Flip com offset
+    // Flip with offset
     assert_approx(xflip(x=5, p=[5,2,3]), [5,2,3], "xflip at x=5, point on plane");
     assert_approx(xflip(x=5, p=[7,2,3]), [3,2,3], "xflip at x=5, point off plane");
     assert_approx(xflip(x=5, p=[0,0,0]), [10,0,0], "xflip at x=5, origin");
-    // Lista de pontos
+    // List of points
     assert_approx(xflip(p=[[1,2,3],[4,5,6]]), [[-1,2,3],[-4,5,6]]);
     // Verify that module at least doesn't crash.
     xflip() union(){};
@@ -349,17 +349,17 @@ include <../std.scad>
 module test_yflip() {
     assert_approx(yflip(), [[1,0,0,0],[0,-1,0,0],[0,0,1,0],[0,0,0,1]]);
     assert_approx(yflip(p=[1,2,3]), [1,-2,3]);
-    // Valor zero permanece zero
+    // Zero value stays zero
     assert_approx(yflip(p=[5,0,10]), [5,0,10]);
-    // Valores negativos
+    // Negative values
     assert_approx(yflip(p=[1,-3,2]), [1,3,2]);
-    // Duplo flip = identidade
+    // Double flip = identity
     assert_approx(yflip() * yflip(), affine3d_identity(), "double yflip = identity");
-    // Flip com offset
+    // Flip with offset
     assert_approx(yflip(y=5, p=[2,5,3]), [2,5,3], "yflip at y=5, point on plane");
     assert_approx(yflip(y=5, p=[2,7,3]), [2,3,3], "yflip at y=5, point off plane");
     assert_approx(yflip(y=5, p=[0,0,0]), [0,10,0], "yflip at y=5, origin");
-    // Lista de pontos
+    // List of points
     assert_approx(yflip(p=[[1,2,3],[4,5,6]]), [[1,-2,3],[4,-5,6]]);
     // Verify that module at least doesn't crash.
     yflip() union(){};
@@ -375,17 +375,17 @@ include <../std.scad>
 module test_zflip() {
     assert_approx(zflip(), [[1,0,0,0],[0,1,0,0],[0,0,-1,0],[0,0,0,1]]);
     assert_approx(zflip(p=[1,2,3]), [1,2,-3]);
-    // Valor zero permanece zero
+    // Zero value stays zero
     assert_approx(zflip(p=[5,10,0]), [5,10,0]);
-    // Valores negativos
+    // Negative values
     assert_approx(zflip(p=[1,2,-3]), [1,2,3]);
-    // Duplo flip = identidade
+    // Double flip = identity
     assert_approx(zflip() * zflip(), affine3d_identity(), "double zflip = identity");
-    // Flip com offset
+    // Flip with offset
     assert_approx(zflip(z=5, p=[2,3,5]), [2,3,5], "zflip at z=5, point on plane");
     assert_approx(zflip(z=5, p=[2,3,7]), [2,3,3], "zflip at z=5, point off plane");
     assert_approx(zflip(z=5, p=[0,0,0]), [0,0,10], "zflip at z=5, origin");
-    // Lista de pontos
+    // List of points
     assert_approx(zflip(p=[[1,2,3],[4,5,6]]), [[1,2,-3],[4,5,-6]]);
     // Verify that module at least doesn't crash.
     zflip() union(){};
@@ -579,9 +579,9 @@ include <../std.scad>
 module test_frame_map() {
     assert(approx(frame_map(x=[1,1,0], y=[-1,1,0]), affine3d_zrot(45)));
     assert(approx(frame_map(x=[0,1,0], y=[0,0,1]), rot(v=[1,1,1],a=120)));
-    // Identidade: eixos padrao
+    // Identity: default axes
     assert_approx(frame_map(x=[1,0,0], y=[0,1,0]), affine3d_identity(), "frame_map identity");
-    // Trocar X e Y equivale a rotacao de 90 em Z com flip
+    // Swapping X and Y axes is equivalent to a 90-degree rotation about Z
     assert_approx(frame_map(x=[0,1,0], y=[-1,0,0]), affine3d_zrot(90), "frame_map 90 deg Z");
 }
 test_frame_map();
@@ -596,24 +596,24 @@ module test_skew() {
     m = affine3d_skew(sxy=2, sxz=3, syx=4, syz=5, szx=6, szy=7);
     assert_approx(skew(sxy=2, sxz=3, syx=4, syz=5, szx=6, szy=7), m);
     assert_approx(skew(sxy=2, sxz=3, syx=4, syz=5, szx=6, szy=7, p=[1,2,3]), apply(m,[1,2,3]));
-    // Skew zero = identidade
+    // Zero skew = identity
     assert_approx(skew(), affine3d_identity(), "skew with no args = identity");
     assert_approx(skew(sxy=0, sxz=0, syx=0, syz=0, szx=0, szy=0), affine3d_identity(), "skew all zeros = identity");
-    // Skew zero aplicado a ponto nao altera
+    // Zero skew applied to a point leaves it unchanged
     assert_approx(skew(p=[5,10,15]), [5,10,15], "skew zero on point = identity");
-    // Skew de eixo individual
+    // Single-axis skew
     assert_approx(skew(sxy=1, p=[1,2,3]), apply(affine3d_skew(sxy=1), [1,2,3]), "skew sxy only");
     assert_approx(skew(sxz=1, p=[1,2,3]), apply(affine3d_skew(sxz=1), [1,2,3]), "skew sxz only");
     assert_approx(skew(syx=1, p=[1,2,3]), apply(affine3d_skew(syx=1), [1,2,3]), "skew syx only");
     assert_approx(skew(syz=1, p=[1,2,3]), apply(affine3d_skew(syz=1), [1,2,3]), "skew syz only");
     assert_approx(skew(szx=1, p=[1,2,3]), apply(affine3d_skew(szx=1), [1,2,3]), "skew szx only");
     assert_approx(skew(szy=1, p=[1,2,3]), apply(affine3d_skew(szy=1), [1,2,3]), "skew szy only");
-    // Skew com valores negativos
+    // Skew with negative values
     assert_approx(skew(sxy=-3, p=[1,2,3]), apply(affine3d_skew(sxy=-3), [1,2,3]), "skew negative sxy");
-    // Skew via angulo
+    // Skew via angle
     assert_approx(skew(axy=45, p=[1,2,3]), skew(sxy=tan(45), p=[1,2,3]), "skew axy=45 == sxy=tan(45)");
     assert_approx(skew(ayx=30, p=[1,2,3]), skew(syx=tan(30), p=[1,2,3]), "skew ayx=30 == syx=tan(30)");
-    // Lista de pontos
+    // List of points
     m2 = affine3d_skew(sxy=2);
     assert_approx(skew(sxy=2, p=[[1,0,0],[0,1,0],[0,0,1]]), apply(m2, [[1,0,0],[0,1,0],[0,0,1]]), "skew point list");
     // Verify that module at least doesn't crash.

--- a/tests/test_vectors.scadtest
+++ b/tests/test_vectors.scadtest
@@ -71,19 +71,19 @@ include <../std.scad>
 module test_v_ceil() {
     assert_equal(v_ceil([2.0, 3.14, 18.9, 7]), [2,4,19,7]);
     assert_equal(v_ceil([-2.0, -3.14, -18.9, -7]), [-2,-3,-18,-7]);
-    // Vetor zero
+    // Zero vector
     assert_equal(v_ceil([0, 0, 0]), [0, 0, 0]);
     assert_equal(v_ceil([0.0, 0.0]), [0, 0]);
-    // Valores inteiros (sem mudanca)
+    // Integer values (no change)
     assert_equal(v_ceil([1, -1, 5, -5]), [1, -1, 5, -5]);
-    // Valores proximos de inteiros
+    // Values close to integers
     assert_equal(v_ceil([0.001, -0.999]), [1, 0]);
     assert_equal(v_ceil([1.001, -1.999]), [2, -1]);
-    // Vetor 2D
+    // 2D vector
     assert_equal(v_ceil([3.2, -2.7]), [4, -2]);
-    // Valores grandes
+    // Large values
     assert_equal(v_ceil([99999.1, -99999.9]), [100000, -99999]);
-    // Vetor unitario com componentes fracionarios
+    // Unit vector with fractional components
     assert_equal(v_ceil([0.5, 0.5, 0.5]), [1, 1, 1]);
     assert_equal(v_ceil([-0.5, -0.5, -0.5]), [0, 0, 0]);
 }
@@ -121,19 +121,19 @@ module test_v_mul() {
     assert_equal(v_mul([3,4,5], [8,7,6]), [24,28,30]);
     assert_equal(v_mul([1,2,3], [4,5,6]), [4,10,18]);
     assert_equal(v_mul([[1,2,3],[4,5,6],[7,8,9]], [[4,5,6],[3,2,1],[5,9,3]]), [32,28,134]);
-    // Multiplicacao por vetor zero
+    // Multiplication by zero vector
     assert_equal(v_mul([1,2,3], [0,0,0]), [0,0,0]);
     assert_equal(v_mul([0,0,0], [5,6,7]), [0,0,0]);
-    // Valores negativos
+    // Negative values
     assert_equal(v_mul([-1,-2,-3], [4,5,6]), [-4,-10,-18]);
     assert_equal(v_mul([-1,-2], [-3,-4]), [3,8]);
-    // Vetor unitario (identidade)
+    // Unit vector (identity)
     assert_equal(v_mul([5,10,15], [1,1,1]), [5,10,15]);
-    // Valores grandes
+    // Large values
     assert_equal(v_mul([1000,2000], [3000,4000]), [3000000,8000000]);
-    // Vetor 2D
+    // 2D vector
     assert_equal(v_mul([3,4], [5,6]), [15,24]);
-    // Multiplicacao com valores fracionarios
+    // Multiplication with fractional values
     assert_approx(v_mul([0.5, 0.25], [2, 4]), [1, 1]);
 }
 test_v_mul();
@@ -146,21 +146,21 @@ include <../std.scad>
 
 module test_v_div() {
     assert(v_div([24,28,30], [8,7,6]) == [3, 4, 5]);
-    // Divisao com valores negativos
+    // Division with negative values
     assert_equal(v_div([-24,28,-30], [8,-7,6]), [-3,-4,-5]);
     assert_equal(v_div([-10,-20], [-2,-5]), [5,4]);
-    // Divisao de zero por nao-zero
+    // Division of zero by non-zero
     assert_equal(v_div([0,0,0], [1,2,3]), [0,0,0]);
-    // Vetor unitario como divisor (identidade)
+    // Unit vector as divisor (identity)
     assert_equal(v_div([5,10,15], [1,1,1]), [5,10,15]);
-    // Valores grandes
+    // Large values
     assert_equal(v_div([9000000,8000000], [3000,4000]), [3000,2000]);
-    // Vetor 2D
+    // 2D vector
     assert_equal(v_div([10,20], [2,5]), [5,4]);
-    // Divisao com resultado fracionario
+    // Division with fractional result
     assert_approx(v_div([1,1,1], [3,3,3]), [1/3, 1/3, 1/3]);
     assert_approx(v_div([1,2], [4,8]), [0.25, 0.25]);
-    // Dividir por si mesmo
+    // Divide by itself
     assert_approx(v_div([7,13,29], [7,13,29]), [1,1,1]);
 }
 test_v_div();
@@ -177,21 +177,21 @@ module test_v_abs() {
     assert(v_abs([-2,4,8]) == [2,4,8]);
     assert(v_abs([2,-4,8]) == [2,4,8]);
     assert(v_abs([2,4,-8]) == [2,4,8]);
-    // Vetor zero
+    // Zero vector
     assert(v_abs([0,0,0]) == [0,0,0]);
     assert(v_abs([0,0]) == [0,0]);
-    // Vetor 2D
+    // 2D vector
     assert(v_abs([-3,4]) == [3,4]);
     assert(v_abs([3,-4]) == [3,4]);
-    // Valores unitarios
+    // Unit values
     assert(v_abs([1,0,0]) == [1,0,0]);
     assert(v_abs([-1,0,0]) == [1,0,0]);
     assert(v_abs([0,-1,0]) == [0,1,0]);
-    // Valores grandes
+    // Large values
     assert(v_abs([-100000, 100000, -99999]) == [100000, 100000, 99999]);
-    // Valores fracionarios
+    // Fractional values
     assert_approx(v_abs([-0.5, 0.25, -0.125]), [0.5, 0.25, 0.125]);
-    // Vetor longo
+    // Long vector
     assert(v_abs([-1,-2,-3,-4,-5]) == [1,2,3,4,5]);
 }
 test_v_abs();
@@ -223,21 +223,21 @@ module test_v_theta() {
     assert_approx(v_theta([0,1,1]), 90);
     assert_approx(v_theta([0,-1,1]), -90);
     assert_approx(v_theta([1,1,1]), 45);
-    // Vetores unitarios nos eixos com magnitude variada
+    // Axis-aligned unit vectors with varying magnitude
     assert_approx(v_theta([100,0]), 0);
     assert_approx(v_theta([0,100]), 90);
     assert_approx(v_theta([-100,0]), 180);
     assert_approx(v_theta([0,-100]), -90);
-    // Angulos em 2D com valores negativos
+    // 2D angles with negative values
     assert_approx(v_theta([-1,-1]), -135);
     assert_approx(v_theta([1,-1]), -45);
-    // Valores grandes em 3D
+    // Large values in 3D
     assert_approx(v_theta([1000, 1000, 0]), 45);
     assert_approx(v_theta([-1000, 1000, 500]), 135);
-    // Vetores com componente Z grande (Z nao afeta theta)
+    // Vectors with large Z component (Z does not affect theta)
     assert_approx(v_theta([1, 0, 99999]), 0);
     assert_approx(v_theta([0, 1, -99999]), 90);
-    // Angulos de 30, 60 graus em 2D
+    // 30 and 60 degree angles in 2D
     assert_approx(v_theta([cos(30), sin(30)]), 30);
     assert_approx(v_theta([cos(60), sin(60)]), 60);
     assert_approx(v_theta([cos(-60), sin(-60)]), -60);
@@ -301,28 +301,28 @@ module test_unit() {
     assert(abs(norm(unit([-10,0,0]))-1) < _EPSILON);
     assert(abs(norm(unit([0,-10,0]))-1) < _EPSILON);
     assert(abs(norm(unit([0,0,-10]))-1) < _EPSILON);
-    // Vetores negativos nos eixos
+    // Negative axis-aligned vectors
     assert_approx(unit([-10,0,0]), [-1,0,0]);
     assert_approx(unit([0,-10,0]), [0,-1,0]);
     assert_approx(unit([0,0,-10]), [0,0,-1]);
-    // Vetores ja unitarios (devem retornar o mesmo)
+    // Already unit vectors (should return unchanged)
     assert_approx(unit([1,0,0]), [1,0,0]);
     assert_approx(unit([0,1,0]), [0,1,0]);
     assert_approx(unit([0,0,1]), [0,0,1]);
-    // Vetor 2D
+    // 2D vector
     assert_approx(unit([3,4]), [0.6, 0.8]);
     assert_approx(unit([-3,4]), [-0.6, 0.8]);
     assert(abs(norm(unit([3,4]))-1) < _EPSILON);
-    // Valores grandes
+    // Large values
     assert(abs(norm(unit([100000,0,0]))-1) < _EPSILON);
     assert_approx(unit([100000,0,0]), [1,0,0]);
-    // Valores pequenos (mas nao zero)
+    // Small values (but not zero)
     assert(abs(norm(unit([0.001, 0, 0]))-1) < _EPSILON);
     assert_approx(unit([0.001, 0, 0]), [1, 0, 0]);
-    // Direcao preservada para vetores diagonais
+    // Direction preserved for diagonal vectors
     assert_approx(unit([1,1,0]), [1/sqrt(2), 1/sqrt(2), 0]);
     assert_approx(unit([1,1,1]), [1/sqrt(3), 1/sqrt(3), 1/sqrt(3)]);
-    // Parametro error para vetor zero
+    // Error parameter for zero vector
     assert_equal(unit([0,0,0], error=[0,0,0]), [0,0,0]);
     assert_equal(unit([0,0,0], error=[1,2,3]), [1,2,3]);
 }
@@ -450,19 +450,19 @@ include <../std.scad>
 
 module test_add_scalar() {
     assert(add_scalar([1,2,3],3) == [4,5,6]);
-    // Somar zero (identidade)
+    // Add zero (identity)
     assert(add_scalar([1,2,3],0) == [1,2,3]);
-    // Somar valor negativo
+    // Add negative value
     assert(add_scalar([1,2,3],-3) == [-2,-1,0]);
-    // Vetor zero
+    // Zero vector
     assert(add_scalar([0,0,0],5) == [5,5,5]);
-    // Vetor 2D
+    // 2D vector
     assert(add_scalar([10,20],5) == [15,25]);
-    // Valores negativos no vetor
+    // Negative values in vector
     assert(add_scalar([-1,-2,-3],3) == [2,1,0]);
-    // Valores grandes
+    // Large values
     assert(add_scalar([100000,200000],1) == [100001,200001]);
-    // Valores fracionarios
+    // Fractional values
     assert_approx(add_scalar([0.1, 0.2, 0.3], 0.5), [0.6, 0.7, 0.8]);
 }
 test_add_scalar();


### PR DESCRIPTION
Translates the Portuguese-language comments added in #1958 to English, per the review request.

Both `tests/test_transforms.scadtest` and `tests/test_vectors.scadtest` are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)