### PR TITLE
Revarbat dev

### DIFF
--- a/vnf.scad
+++ b/vnf.scad
@@ -49,8 +49,9 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //   * "alt" &mdash; uniform subdivision in the other (alternate) direction
 //   * "flip1" &mdash; arbitrary division that alternates the direction adjacent pairs of quadrilaterals.
 //   * "flip2" &mdash; the alternating division that is the opposite of "flip1". 
-//   * "min_edge" &mdash; subdivide each quadrilateral on its shorter edge, so the division may not be uniform across the shape
-//   * "min_area" &mdash; creates the triangulation with the minimal area.
+//   * "max_edge" &mdash; subdivide each quadrilateral on its longer edge, so the division may not be uniform across the shape
+//   * "min_edge" &mdash; subdivide each quadrilateral on its shorter edge.  The opposite of "max_edge".
+//   * "min_area" &mdash; creates the triangulation with the minimal area.  This is often, but not always the same as "min_edge"
 //   * "quincunx" &mdash; adds a vertex in the center of each quadrilateral and creates four triangles
 //   * "convex" &mdash; choose the locally convex division
 //   * "concave" &mdash; choose the locally concave division
@@ -332,7 +333,7 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //     color("#0dd") vnf_wireframe(vnf, width=0.4);
 //     color("black") vnf_wireframe(grid_vnf, width=0.5);
 //     txt = str("style = ", style);
-//     rot($vpr) move([50,-35]) color("black")
+//     rot($vpr) move([70,-30]) color("black")
 //       text(txt, size=10, halign="center", valign="top");
 //   }
 //   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
@@ -346,7 +347,7 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //     color("#0dd") vnf_wireframe(vnf, width=0.4);
 //     color("black") vnf_wireframe(grid_vnf, width=0.5);
 //     txt = str("style = ", style);
-//     rot($vpr) move([50,-35]) color("black")
+//     rot($vpr) move([70,-30]) color("black")
 //       text(txt, size=10, halign="center", valign="top");
 //   }
 //   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
@@ -360,7 +361,7 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //     color("#0dd") vnf_wireframe(vnf, width=0.4);
 //     color("black") vnf_wireframe(grid_vnf, width=0.5);
 //     txt = str("style = ", style);
-//     move([50,0,-25]) rot($vpr) color("black")
+//     rot($vpr) move([70,-30]) color("black")
 //       text(txt, size=10, halign="center", valign="top");
 //   }
 //   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
@@ -374,7 +375,7 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //     color("#0dd") vnf_wireframe(vnf, width=0.4);
 //     color("black") vnf_wireframe(grid_vnf, width=0.5);
 //     txt = str("style = ", style);
-//     rot($vpr) move([50,-35]) color("black")
+//     rot($vpr) move([70,-30]) color("black")
 //       text(txt, size=10, halign="center", valign="top");
 //   }
 //   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
@@ -388,7 +389,7 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //     color("#0dd") vnf_wireframe(vnf, width=0.4);
 //     color("black") vnf_wireframe(grid_vnf, width=0.5);
 //     txt = str("style = ", style);
-//     rot($vpr) move([50,-35]) color("black")
+//     rot($vpr) move([70,-30]) color("black")
 //       text(txt, size=10, halign="center", valign="top");
 //   }
 //   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
@@ -402,7 +403,7 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //     color("#0dd") vnf_wireframe(vnf, width=0.4);
 //     color("black") vnf_wireframe(grid_vnf, width=0.5);
 //     txt = str("style = ", style);
-//     rot($vpr) move([50,-35]) color("black")
+//     rot($vpr) move([70,-30]) color("black")
 //       text(txt, size=10, halign="center", valign="top");
 //   }
 //   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
@@ -416,7 +417,7 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //     color("#0dd") vnf_wireframe(vnf, width=0.4);
 //     color("black") vnf_wireframe(grid_vnf, width=0.5);
 //     txt = str("style = ", style);
-//     rot($vpr) move([50,-35]) color("black")
+//     rot($vpr) move([70,-30]) color("black")
 //       text(txt, size=10, halign="center", valign="top");
 //   }
 //   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
@@ -430,12 +431,12 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //     color("#0dd") vnf_wireframe(vnf, width=0.4);
 //     color("black") vnf_wireframe(grid_vnf, width=0.5);
 //     txt = str("style = ", style);
-//     rot($vpr) move([50,-35]) color("black")
+//     rot($vpr) move([70,-30]) color("black")
 //       text(txt, size=10, halign="center", valign="top");
 //   }
 //   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
 //   show_triangulation(fn, "concave", steps=4);
-// Example(3D,VPT=[50,44,-4.5],VPD=400): Triangulating using `style="min_edge"`.  This triangulates in a way that minimizes face edge lengths.
+// Example(3D,VPT=[50,44,-4.5],VPD=400): Triangulating using `style="max_edge"`.  This selects the longer diagonal.
 //   module show_triangulation(fn, style, steps) {
 //     pts = [for(u=[0:100/steps:100]) [for(v=[0:100/steps:100]) fn(u,v)]];
 //     vnf = vnf_vertex_array(pts, style=style);
@@ -444,11 +445,25 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //     color("#0dd") vnf_wireframe(vnf, width=0.4);
 //     color("black") vnf_wireframe(grid_vnf, width=0.5);
 //     txt = str("style = ", style);
-//     rot($vpr) move([50,-35]) color("black")
+//     rot($vpr) move([70,-30]) color("black")
 //       text(txt, size=10, halign="center", valign="top");
 //   }
 //   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
-//   show_triangulation(fn, "concave", steps=4);
+//   show_triangulation(fn, "max_edge", steps=4);
+// Example(3D,VPT=[50,44,-4.5],VPD=400): Triangulating using `style="min_edge"`.  This selects the shorter diagonal.
+//   module show_triangulation(fn, style, steps) {
+//     pts = [for(u=[0:100/steps:100]) [for(v=[0:100/steps:100]) fn(u,v)]];
+//     vnf = vnf_vertex_array(pts, style=style);
+//     grid_vnf = vnf_vertex_array(pts, style="quad");
+//     color("#ccf") vnf_polyhedron(vnf);
+//     color("#0dd") vnf_wireframe(vnf, width=0.4);
+//     color("black") vnf_wireframe(grid_vnf, width=0.5);
+//     txt = str("style = ", style);
+//     rot($vpr) move([70,-30]) color("black")
+//       text(txt, size=10, halign="center", valign="top");
+//   }
+//   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
+//   show_triangulation(fn, "min_edge", steps=4);
 // Example(3D,VPT=[50,44,-4.5],VPD=400): Triangulating using `style="min_area"`.  This triangulates in a way that minimizes face areas.
 //   module show_triangulation(fn, style, steps) {
 //     pts = [for(u=[0:100/steps:100]) [for(v=[0:100/steps:100]) fn(u,v)]];
@@ -458,11 +473,11 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //     color("#0dd") vnf_wireframe(vnf, width=0.4);
 //     color("black") vnf_wireframe(grid_vnf, width=0.5);
 //     txt = str("style = ", style);
-//     rot($vpr) move([50,-35]) color("black")
+//     rot($vpr) move([70,-30]) color("black")
 //       text(txt, size=10, halign="center", valign="top");
 //   }
 //   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
-//   show_triangulation(fn, "concave", steps=4);
+//   show_triangulation(fn, "min_area", steps=4);
 
 module vnf_vertex_array(
     points,
@@ -496,7 +511,7 @@ function vnf_vertex_array(
     texture, tex_reps, tex_size, tex_samples, tex_inset=false, tex_rot=0, tex_scaling="default",
     tex_depth=1, tex_extra, tex_skip, sidecaps,sidecap1,sidecap2, normals
 ) =
-    assert(in_list(style,["default","alt","quincunx", "convex","concave", "min_edge","min_area","flip1","flip2","quad"]))
+    assert(in_list(style,["default","alt","quincunx", "convex","concave", "max_edge", "min_edge","min_area","flip1","flip2","quad"]))
     assert(is_matrix(points[0], n=3),"\nPoint array has the wrong shape or points are not 3d.")
     assert(is_consistent(points), "\nNon-rectangular or invalid point array (vnf_tri_array() may work).")
     assert(is_bool(triangulate))
@@ -555,6 +570,15 @@ function vnf_vertex_array(
                                  : [[i1,i3,i2],[i1,i4,i3]]
                           )
                           minarea_edge
+                      : style=="max_edge"?
+                          let(
+                               d42=norm(pts[i4]-pts[i2]),
+                               d13=norm(pts[i1]-pts[i3]),
+                               longedge = d42>d13-_EPSILON
+                                 ? [[i1,i4,i2],[i2,i4,i3]]
+                                 : [[i1,i3,i2],[i1,i4,i3]]
+                          )
+                          longedge
                       : style=="min_edge"?
                           let(
                                d42=norm(pts[i4]-pts[i2]),

--- a/vnf.scad
+++ b/vnf.scad
@@ -332,8 +332,8 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //     color("#0dd") vnf_wireframe(vnf, width=0.4);
 //     color("black") vnf_wireframe(grid_vnf, width=0.5);
 //     txt = str("style = ", style);
-//     move([50,0,-20]) rot($vpr) color("black")
-//       text(txt, size=5, halign="center", valign="top");
+//     rot($vpr) move([50,-35]) color("black")
+//       text(txt, size=10, halign="center", valign="top");
 //   }
 //   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
 //   show_triangulation(fn, "default", steps=4);
@@ -346,8 +346,8 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //     color("#0dd") vnf_wireframe(vnf, width=0.4);
 //     color("black") vnf_wireframe(grid_vnf, width=0.5);
 //     txt = str("style = ", style);
-//     move([50,0,-20]) rot($vpr) color("black")
-//       text(txt, size=5, halign="center", valign="top");
+//     rot($vpr) move([50,-35]) color("black")
+//       text(txt, size=10, halign="center", valign="top");
 //   }
 //   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
 //   show_triangulation(fn, "alt", steps=4);
@@ -360,8 +360,8 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //     color("#0dd") vnf_wireframe(vnf, width=0.4);
 //     color("black") vnf_wireframe(grid_vnf, width=0.5);
 //     txt = str("style = ", style);
-//     move([50,0,-20]) rot($vpr) color("black")
-//       text(txt, size=5, halign="center", valign="top");
+//     move([50,0,-25]) rot($vpr) color("black")
+//       text(txt, size=10, halign="center", valign="top");
 //   }
 //   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
 //   show_triangulation(fn, "flip1", steps=4);
@@ -374,8 +374,8 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //     color("#0dd") vnf_wireframe(vnf, width=0.4);
 //     color("black") vnf_wireframe(grid_vnf, width=0.5);
 //     txt = str("style = ", style);
-//     move([50,0,-20]) rot($vpr) color("black")
-//       text(txt, size=5, halign="center", valign="top");
+//     rot($vpr) move([50,-35]) color("black")
+//       text(txt, size=10, halign="center", valign="top");
 //   }
 //   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
 //   show_triangulation(fn, "flip2", steps=4);
@@ -388,8 +388,8 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //     color("#0dd") vnf_wireframe(vnf, width=0.4);
 //     color("black") vnf_wireframe(grid_vnf, width=0.5);
 //     txt = str("style = ", style);
-//     move([50,0,-20]) rot($vpr) color("black")
-//       text(txt, size=5, halign="center", valign="top");
+//     rot($vpr) move([50,-35]) color("black")
+//       text(txt, size=10, halign="center", valign="top");
 //   }
 //   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
 //   show_triangulation(fn, "quad", steps=4);
@@ -402,8 +402,8 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //     color("#0dd") vnf_wireframe(vnf, width=0.4);
 //     color("black") vnf_wireframe(grid_vnf, width=0.5);
 //     txt = str("style = ", style);
-//     move([50,0,-20]) rot($vpr) color("black")
-//       text(txt, size=5, halign="center", valign="top");
+//     rot($vpr) move([50,-35]) color("black")
+//       text(txt, size=10, halign="center", valign="top");
 //   }
 //   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
 //   show_triangulation(fn, "quincunx", steps=4);
@@ -416,8 +416,8 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //     color("#0dd") vnf_wireframe(vnf, width=0.4);
 //     color("black") vnf_wireframe(grid_vnf, width=0.5);
 //     txt = str("style = ", style);
-//     move([50,0,-20]) rot($vpr) color("black")
-//       text(txt, size=5, halign="center", valign="top");
+//     rot($vpr) move([50,-35]) color("black")
+//       text(txt, size=10, halign="center", valign="top");
 //   }
 //   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
 //   show_triangulation(fn, "convex", steps=4);
@@ -430,8 +430,8 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //     color("#0dd") vnf_wireframe(vnf, width=0.4);
 //     color("black") vnf_wireframe(grid_vnf, width=0.5);
 //     txt = str("style = ", style);
-//     move([50,0,-20]) rot($vpr) color("black")
-//       text(txt, size=5, halign="center", valign="top");
+//     rot($vpr) move([50,-35]) color("black")
+//       text(txt, size=10, halign="center", valign="top");
 //   }
 //   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
 //   show_triangulation(fn, "concave", steps=4);
@@ -444,8 +444,8 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //     color("#0dd") vnf_wireframe(vnf, width=0.4);
 //     color("black") vnf_wireframe(grid_vnf, width=0.5);
 //     txt = str("style = ", style);
-//     move([50,0,-20]) rot($vpr) color("black")
-//       text(txt, size=5, halign="center", valign="top");
+//     rot($vpr) move([50,-35]) color("black")
+//       text(txt, size=10, halign="center", valign="top");
 //   }
 //   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
 //   show_triangulation(fn, "concave", steps=4);
@@ -458,8 +458,8 @@ EMPTY_VNF = [[],[]];  // The standard empty VNF with no vertices or faces.
 //     color("#0dd") vnf_wireframe(vnf, width=0.4);
 //     color("black") vnf_wireframe(grid_vnf, width=0.5);
 //     txt = str("style = ", style);
-//     move([50,0,-20]) rot($vpr) color("black")
-//       text(txt, size=5, halign="center", valign="top");
+//     rot($vpr) move([50,-35]) color("black")
+//       text(txt, size=10, halign="center", valign="top");
 //   }
 //   fn = function(u,v) [u, v, 16*sin(u*1.8)*-cos(v*1.8)];
 //   show_triangulation(fn, "concave", steps=4);


### PR DESCRIPTION
This pull request updates the `vnf.scad` file to add a new triangulation style, improve documentation, and enhance the demonstration examples for mesh subdivision. The main new feature is the introduction of the `"max_edge"` style, which selects the longer diagonal when subdividing quadrilaterals. Additionally, the documentation and example code have been updated to clarify the behavior of the different subdivision styles and improve visualization.

**New triangulation style:**

* Added the `"max_edge"` style to `vnf_vertex_array`, which subdivides each quadrilateral along its longer edge. This is now supported in the assertion for allowed styles and in the triangulation logic. [[1]](diffhunk://#diff-2543c8c6c32ffd2057934a9d00766352690cd60714dc31462f5a06d326de802cL499-R514) [[2]](diffhunk://#diff-2543c8c6c32ffd2057934a9d00766352690cd60714dc31462f5a06d326de802cR573-R581)

**Documentation improvements:**

* Updated the documentation comments to describe the new `"max_edge"` style, clarify its relationship with `"min_edge"`, and provide more accurate descriptions for `"min_area"` and related styles.

**Example and visualization enhancements:**

* Improved the code for example visualizations by increasing text size, adjusting position, and updating the demonstration sequence to include the new `"max_edge"` and revised `"min_edge"` examples. [[1]](diffhunk://#diff-2543c8c6c32ffd2057934a9d00766352690cd60714dc31462f5a06d326de802cL335-R337) [[2]](diffhunk://#diff-2543c8c6c32ffd2057934a9d00766352690cd60714dc31462f5a06d326de802cL349-R351) [[3]](diffhunk://#diff-2543c8c6c32ffd2057934a9d00766352690cd60714dc31462f5a06d326de802cL363-R365) [[4]](diffhunk://#diff-2543c8c6c32ffd2057934a9d00766352690cd60714dc31462f5a06d326de802cL377-R379) [[5]](diffhunk://#diff-2543c8c6c32ffd2057934a9d00766352690cd60714dc31462f5a06d326de802cL391-R393) [[6]](diffhunk://#diff-2543c8c6c32ffd2057934a9d00766352690cd60714dc31462f5a06d326de802cL405-R407) [[7]](diffhunk://#diff-2543c8c6c32ffd2057934a9d00766352690cd60714dc31462f5a06d326de802cL419-R421) [[8]](diffhunk://#diff-2543c8c6c32ffd2057934a9d00766352690cd60714dc31462f5a06d326de802cL433-R439) [[9]](diffhunk://#diff-2543c8c6c32ffd2057934a9d00766352690cd60714dc31462f5a06d326de802cL447-R466) [[10]](diffhunk://#diff-2543c8c6c32ffd2057934a9d00766352690cd60714dc31462f5a06d326de802cL461-R480)

These changes make the triangulation options more flexible and the documentation and examples clearer for users.