### PR TITLE
Add support for mason jar and garden hose threads

### DIFF
--- a/bottlecaps.scad
+++ b/bottlecaps.scad
@@ -33,17 +33,17 @@ include <rounding.scad>
 // Arguments:
 //   wall = Wall thickness in mm.
 //   ---
-//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   anchor = Translate so anchor point is at origin (0,0,0). See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Named Anchors:
 //   "tamper-ring" = Centered at the top of the anti-tamper ring channel.
 //   "support-ring" = Centered at the bottom of the support ring.
 // Example:
 //   pco1810_neck();
-// Example: Standard Anchors
+// Example: Standard anchors
 //   pco1810_neck() show_anchors(custom=false);
-// Example: Custom Named Anchors
+// Example: Custom named anchors
 //   expose_anchors(0.3)
 //       pco1810_neck()
 //           show_anchors(std=false);
@@ -162,9 +162,9 @@ function  pco1810_neck(wall=2, anchor="support-ring", spin=0, orient=UP) =
 //   wall = Wall thickness in mm.
 //   texture = The surface texture of the cap.  Valid values are "none", "knurled", or "ribbed".  Default: "none"
 //   ---
-//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top toward, after spin. See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `BOTTOM`
+//   spin = Rotate this many degrees around the Z axis after anchor. See [spin](attachments.scad#subsection-spin)  Default: 0
+//   orient = Vector to rotate top toward, after spin. See [orient](attachments.scad#subsection-orient). Default: `UP`
 // Named Anchors:
 //   "inside-top" = Centered on the inside top of the cap.
 // Examples:
@@ -190,8 +190,8 @@ module pco1810_cap(h, r, d, wall, texture="none", anchor=BOTTOM, spin=0, orient=
     wwall = default(u_sub(rr,cap_id/2), default(wall, 2));
     hh = default(h, tamper_ring_h + wwall);
     checks =
-        assert(wwall >= 0, "wall can't be negative.")
-        assert(hh >= tamper_ring_h, str("height can't be less than ", tamper_ring_h, "."));
+        assert(wwall >= 0, "\nwall can't be negative.")
+        assert(hh >= tamper_ring_h, str("\nheight can't be less than ", tamper_ring_h, "."));
 
     $fn = segs(33/2);
     w = cap_id + 2*wwall;
@@ -240,8 +240,8 @@ function pco1810_cap(h, r, d, wall, texture="none", anchor=BOTTOM, spin=0, orien
 // Arguments:
 //   wall = Wall thickness in mm.
 //   ---
-//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: "support_ring"
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Named Anchors:
 //   "tamper-ring" = Centered at the top of the anti-tamper ring channel.
@@ -366,8 +366,8 @@ function pco1881_neck(wall=2, anchor="support-ring", spin=0, orient=UP) =
 //   wall = Wall thickness in mm.
 //   texture = The surface texture of the cap.  Valid values are "none", "knurled", or "ribbed".  Default: "none"
 //   ---
-//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `BOTTOM`
+//   spin = Rotate this many degrees around the Z axis after anchor. See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Named Anchors:
 //   "inside-top" = Centered on the inside top of the cap.
@@ -375,9 +375,9 @@ function pco1881_neck(wall=2, anchor="support-ring", spin=0, orient=UP) =
 //   pco1881_cap();
 //   pco1881_cap(texture="knurled");
 //   pco1881_cap(texture="ribbed");
-// Example: Standard Anchors
+// Example: Standard anchors
 //   pco1881_cap(texture="ribbed") show_anchors(custom=false);
-// Example: Custom Named Anchors
+// Example: Custom named anchors
 //   expose_anchors(0.5)
 //       pco1881_cap(texture="ribbed")
 //           show_anchors(std=false);
@@ -437,7 +437,7 @@ function pco1881_cap(wall=2, texture="none", anchor=BOTTOM, spin=0, orient=UP) =
 //   support_d = Outer diameter of support ring. Set to 0 for no support. Default: 33
 //   pitch = Thread pitch. Default: 2.7
 //   round_supp = True to round the lower edge of the support ring. Default: false
-//   anchor = Translate so anchor point is at origin (0,0,0). See [anchor](attachments.scad#subsection-anchor).  Default: `"support-ring"`
+//   anchor = Translate so anchor point is at origin (0,0,0). See [anchor](attachments.scad#subsection-anchor).  Default: "support-ring"
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Named Anchors:
@@ -466,7 +466,7 @@ module generic_bottle_neck(
     diamMagMult = neck_d / 26.19;
     heightMagMult = height / 17.00;
 
-    assert(all_nonnegative([support_d]),"support_d must be a nonnegative number");
+    assert(all_nonnegative([support_d]),"\nsupport_d must be a nonnegative number.");
     sup_r = 0.30 * (heightMagMult > 1 ? heightMagMult : 1);
     support_r = floor(((supp_d == neck_d) ? sup_r : min(sup_r, (supp_d - neck_d) / 2)) * 5000) / 10000;
     support_rad = (wall == undef || !round_supp) ? support_r :
@@ -593,14 +593,14 @@ module generic_bottle_cap(
     orient = UP
 ) {
     $fn = segs(33 / 2);
-    dummy = assert(num_defined([thread_od,neck_od,thread_depth])==2, "Must define exactly two of thread_od, neck_od and thread_depth")
-            assert(is_def(thread_depth) || (all_positive([neck_od,thread_od]) && thread_od>neck_od), "thread_od must be larger than neck_od")
-            assert(is_undef(thread_depth) || all_positive([thread_depth,first_defined([neck_od,thread_od])]), "thread_depth, and neck_od/thread_od must be positive");
-    thread_depth = !is_undef(thread_depth) ? thread_depth :  (thread_od - neck_od)/2;
+    dummy = assert(num_defined([thread_od,neck_od,thread_depth])==2, "\nMust define exactly two of thread_od, neck_od and thread_depth.")
+            assert(is_def(thread_depth) || (all_positive([neck_od,thread_od]) && thread_od>neck_od), "\nthread_od must be larger than neck_od.")
+            assert(is_undef(thread_depth) || all_positive([thread_depth,first_defined([neck_od,thread_od])]), "\nthread_depth, and neck_od/thread_od must be positive.");
+    thread_depth = !is_undef(thread_depth) ? thread_depth : (thread_od - neck_od)/2;
     neck_od = !is_undef(neck_od) ? neck_od : thread_od-2*thread_depth;
     thread_od = !is_undef(thread_od) ? thread_od : neck_od+2*thread_depth;
     threadOuterDTol = thread_od + 2*tolerance;
-    w = threadOuterDTol + 2 * wall;                               
+    w = threadOuterDTol + 2 * wall;
     h = height + wall;
     neckOuterDTol = neck_od + 2 * tolerance;
 
@@ -672,7 +672,7 @@ function generic_bottle_cap(
 //   d = Distance between bottom of neck and top of cap. Default: 0
 //   taper_lead_in = Length to leave straight before tapering on tube between neck and cap if exists. Default: 0
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Examples:
 //   bottle_adapter_neck_to_cap();
@@ -708,7 +708,7 @@ module bottle_adapter_neck_to_cap(
 
     top_h = neck_h + max(1,neck_h/17)*sign(neck_support_od);
     bot_h = cap_h + cap_wall;
-    attachable(anchor=anchor,orient=orient,spin=spin, r=max([neck_id/2+wallt1, cap_neck_id/2+wallt2, neck_support_od/2]), h=top_h+bot_h+d) {      
+    attachable(anchor=anchor,orient=orient,spin=spin, r=max([neck_id/2+wallt1, cap_neck_id/2+wallt2, neck_support_od/2]), h=top_h+bot_h+d) {
       zmove((bot_h-top_h)/2)
         difference(){
             union(){
@@ -797,7 +797,7 @@ function bottle_adapter_neck_to_cap(
 //   neck_id2 = Inner diameter of cutout in bottom cap.
 //   taper_lead_in = Length to leave straight before tapering on tube between caps if exists.
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Examples:
 //   bottle_adapter_cap_to_cap();
@@ -909,7 +909,7 @@ function bottle_adapter_cap_to_cap(
 //   d = Distance between bottoms of necks. Default: 0
 //   neck_od1 = Outer diameter of top neck without threads. Default: 24.8
 //   neck_id1 = Inner diameter of top neck. Default 21.4
-//   thread_od1 = Outer diameter of threads on top neck. Default: 27.4
+//   thread_od1 = Outer diameter of threads on top neck. Default: 27.6
 //   height1 =  Height of top neck above support ring. Default: 17
 //   support_od1 = Outer diameter of the support ring on the top neck. Set to 0 for no ring. Default: 33
 //   thread_pitch1 = Thread pitch of top neck.
@@ -922,7 +922,7 @@ function bottle_adapter_cap_to_cap(
 //   taper_lead_in = Length to leave straight before tapering on tube between necks if exists.
 //   wall = Thickness of tube wall between necks.  Leave undefined to match outer diameters with the neckODs/supportODs.
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Examples:
 //   bottle_adapter_neck_to_neck();
@@ -937,7 +937,7 @@ module bottle_adapter_neck_to_neck(
     neck_od2, neck_id2,
     thread_od2, height2,
     support_od2,  pitch2,
-    taper_lead_in = 0, wall, anchor, spin, orient
+    taper_lead_in = 0, wall, anchor=CENTER, spin, orient
 ) {
     neck_od2 = (neck_od2 == undef) ? neck_od1 : neck_od2;
     neck_id2 = (neck_id2 == undef) ? neck_id1 : neck_id2;
@@ -1057,7 +1057,7 @@ function bottle_adapter_neck_to_neck(
 //   style = Either "L" or "M" to specify the thread style.  Default: "L"
 //   bead = if true apply a bead to the neck.  Default: false
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Examples:
 //   sp_neck(48,400,2);
@@ -1175,10 +1175,10 @@ module sp_neck(diam,type,wall,id,style="L",bead=false, anchor, spin, orient)
     assert(num_defined([wall,id])==1, "\nMust define exactly one of wall and id.");
     
     table = struct_val(_sp_specs,type);
-    dum1=assert(is_def(table),"\nUnknown SP closure type.  Type must be one of 400, 410, or 415.");
+    dum1=assert(is_def(table),"\nUnknown SP closure type. Must be one of 400, 410, or 415.");
     entry = struct_val(table, diam);
     dum2=assert(is_def(entry), str("\nUnknown closure nominal diameter. Allowed diameters for SP",type,": ",struct_keys(table)))
-         assert(style=="L" || style=="M", "style must be \"L\" or \"M\"");
+         assert(style=="L" || style=="M", "\nstyle must be \"L\" or \"M\".");
 
     T = entry[0];
     I = entry[1];
@@ -1278,20 +1278,20 @@ module sp_neck(diam,type,wall,id,style="L",bead=false, anchor, spin, orient)
 //   texture = texture for outside of cap, one of "knurled", "ribbed" or "none.  Default: "none"
 //   $slop = Increase inner diameter by `2 * $slop`.  
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Examples:
 //   sp_cap(48,400,2);
 //   sp_cap(22,400,2);
 //   sp_cap(22,410,2);
 //   sp_cap(28,415,1.5,style="M");
-module sp_cap(diam,type,wall,style="L",top_adj=0, bot_adj=0, texture="none", anchor, spin, orient)
+module sp_cap(diam,type,wall,style="L",top_adj=0, bot_adj=0, texture="none", anchor=CENTER, spin=0, orient=UP)
 {
     table = struct_val(_sp_specs,type);
-    dum1=assert(is_def(table),"\nUnknown SP closure type. Type must be one of 400, 410, or 415");
+    dum1=assert(is_def(table),"\nUnknown SP closure type. Must be one of 400, 410, or 415.");
     entry = struct_val(table, diam);
     dum2=assert(is_def(entry), str("\nUnknown closure nominal diameter. Allowed diameters for SP",type,": ",struct_keys(table)))
-         assert(style=="L" || style=="M", "style must be \"L\" or \"M\"");
+         assert(style=="L" || style=="M", "\nstyle must be \"L\" or \"M\".");
 
     T = entry[0];
     I = entry[1];
@@ -1302,7 +1302,7 @@ module sp_cap(diam,type,wall,style="L",top_adj=0, bot_adj=0, texture="none", anc
 
     twist = struct_val(_sp_twist, type);
 
-    dum3=assert(top_adj<S+0.75*a, str("\nThe top_adj value is too large so the thread cannot fit. It must be smaller than ",S+0.75*a));
+    dum3=assert(top_adj<S+0.75*a, str("\nThe top_adj value is too large so the thread cannot fit. It must be smaller than ",S+0.75*a,"."));
     oprofile = _sp_thread_profile(tpi,a,S+0.75*a-top_adj,style,flip=true);
     bounds=pointlist_bounds(oprofile);
     profile = fwd(-bounds[0].y,yflip(oprofile));
@@ -1347,7 +1347,7 @@ function sp_diameter(diam,type) =
   let(
       table = struct_val(_sp_specs,type)
   )
-  assert(is_def(table),"\nUnknown SP closure type. Type must be one of 400, 410, or 415.")
+  assert(is_def(table),"\nUnknown SP closure type. Must be one of 400, 410, or 415.")
   let(
       entry = struct_val(table, diam)
   )
@@ -1389,7 +1389,7 @@ function sp_diameter(diam,type) =
 //   style = Either "L" or "M" to specify the thread style.  Default: "L"
 //   bead = if true apply a bead to the neck.  Default: false
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Examples:
 //   mason_neck(70,400,2);
@@ -1455,15 +1455,15 @@ function _gl_thread_profile(tpi, a, S, style, flip=false) =
 
 
 function mason_neck(diam,type,wall,id,style="L",bead=false, anchor, spin, orient) = no_function("mason_neck");
-module mason_neck(diam,type,wall,id,style="L",bead=false, anchor, spin, orient)
+module mason_neck(diam,type,wall,id,style="L", bead=false, anchor=CENTER, spin=0, orient=UP)
 {
     assert(num_defined([wall,id])==1, "\nMust define exactly one of wall and id.");
     
     table = struct_val(_gl_specs,type);
-    dum1=assert(is_def(table),"\nUnknown glass jar closure type. Type must be 400 or 450.");
+    dum1=assert(is_def(table),"\nUnknown glass jar closure type. Must be 400 or 450.");
     entry = struct_val(table, diam);
-    dum2=assert(is_def(entry), str("\nUnknown closure nominal diameter. Allowed diameters for glass ",type,": ",struct_keys(table)))
-         assert(style=="L" || style=="M", "style must be \"L\" or \"M\"");
+    dum2=assert(is_def(entry), str("\nUnknown closure nominal diameter. Allowed diameters for type ",type,": ",struct_keys(table)))
+         assert(style=="L" || style=="M", "\nstyle must be \"L\" or \"M\".");
 
     T = entry[0];
     I = entry[1];
@@ -1517,18 +1517,18 @@ module mason_neck(diam,type,wall,id,style="L",bead=false, anchor, spin, orient)
 //   Make a GPI (Glass Packaging Institute) threaded mason jar cap. You must
 //   supply the nominal outer diameter of the threads and the thread type, 
 //   400 or 450. While the 400 type neck has 370° of thread, and the 450
-//   neck has 460° of thread, the cap thread is increased by 1.35 times.
+//   neck has 460° of thread, the cap thread is increased by 1.35 times these amounts.
 //   You can also choose between the symmetric L style thread and the asymmetric
 //   M style buttress thread.  The M style may be good for 3d printing if printed with the flat face up.  
 //   It is OK to mix styles, so you can put an L-style cap onto an M-style neck.  
 //   .
 //   The bot_adj parameter specifies an amount to reduce that bottom extension, which might be
 //   necessary if the cap bottoms out on the bead.  Be careful that you don't shrink past the threads,
-//   especially if making adjustments to 400 caps that have a small bottom extension.  
+//   especially if making adjustments to type 400 caps that have a small bottom extension.  
 //   These caps often contain a cardboard or foam sealer disk, which can be as much as 1mm thick, and
 //   would cause the cap to stop in a higher position.
 //   .
-//   You can also adjust the space between the top of the cap and the threads using top_adj. This
+//   You can also adjust the space between the top of the cap and the threads using `top_adj`. This
 //   changes how the threads engage when the cap is fully seated.
 //   .
 //   The inner diameter of the cap is set to allow 10% of the thread depth in clearance.  The diameter
@@ -1544,19 +1544,19 @@ module mason_neck(diam,type,wall,id,style="L",bead=false, anchor, spin, orient)
 //   texture = texture for outside of cap, one of "knurled", "ribbed" or "none.  Default: "none"
 //   $slop = Increase inner diameter by `2 * $slop`.  
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Examples:
 //   mason_cap(70,450,2);
 //   mason_cap(86,400,2);
 
 function mason_cap(diam,type,wall,style="L",top_adj=3, bot_adj=0, texture="none", anchor, spin, orient) = no_function("mason_cap");
-module mason_cap(diam,type,wall,style="L",top_adj=3, bot_adj=0, texture="none", anchor, spin, orient)
+module mason_cap(diam,type,wall,style="L",top_adj=3, bot_adj=0, texture="none", anchor=CENTER, spin=0, orient=UP)
 {
     table = struct_val(_gl_specs,type);
-    dum1=assert(is_def(table),"\nUnknown glass jar closure type. Type must be 400 or 450.");
+    dum1=assert(is_def(table),"\nUnknown glass jar closure type. Must be 400 or 450.");
     entry = struct_val(table, diam);
-    dum2=assert(is_def(entry), str("\nUnknown closure nominal diameter. Allowed diameters for glass ",type,": ",struct_keys(table)))
+    dum2=assert(is_def(entry), str("\nUnknown closure nominal diameter. Allowed diameters for type ",type,": ",struct_keys(table)))
          assert(style=="L" || style=="M", "\nstyle must be \"L\" or \"M\"");
 
     T = entry[0];
@@ -1567,7 +1567,7 @@ module mason_cap(diam,type,wall,style="L",top_adj=3, bot_adj=0, texture="none", 
     a = struct_val(_gl_thread_width,tpi);
     twist = struct_val(_gl_twist, type) * 1.35;
 
-    dum3=assert(top_adj<S+0.75*a, str("\nThe top_adj value is too large so the thread cannot fit. It must be smaller than ",S+0.75*a));
+    dum3=assert(top_adj<S+0.75*a, str("\nThe top_adj value is too large so the thread cannot fit. It must be smaller than ",S+0.75*a,"."));
     oprofile = _sp_thread_profile(tpi,a,S+0.75*a-top_adj,style,flip=true);
     bounds=pointlist_bounds(oprofile);
     profile = fwd(-bounds[0].y,yflip(oprofile));

--- a/bottlecaps.scad
+++ b/bottlecaps.scad
@@ -562,10 +562,10 @@ function generic_bottle_neck(
 //   wall = Wall thickness.  Default: 2
 //   texture = The surface texture of the cap.  Valid values are "none", "knurled", or "ribbed".  Default: "none"
 //   ---
-//   height = Interior height of the cap. Default: 11.2
-//   thread_od = Outer diameter of the threads. Default: 25.1
-//   neck_od = Outer diameter of neck. Default: undef
-//   thread_depth = Depth of the threads. Default: 1.6
+//   height = Interior height of the cap.
+//   thread_od = Outer diameter of the threads.
+//   neck_od = Outer diameter of neck.
+//   thread_depth = Depth of the threads.
 //   tolerance = Extra space to add to the outer diameter of threads and neck. Applied to radius. Default: 0.2
 //   flank_angle = Angle of taper on threads. Default: 15
 //   pitch = Thread pitch. Default: 2.7
@@ -581,9 +581,9 @@ function generic_bottle_neck(
 module generic_bottle_cap(
     wall = 2,
     texture = "none",
-    height = 11.2,
-    thread_depth = 1.6,
-    thread_od = 25.1,
+    height,
+    thread_depth,
+    thread_od,
     tolerance = 0.2,
     neck_od,
     flank_angle = 15,
@@ -912,7 +912,7 @@ function bottle_adapter_cap_to_cap(
 //   thread_od1 = Outer diameter of threads on top neck. Default: 27.6
 //   height1 =  Height of top neck above support ring. Default: 17
 //   support_od1 = Outer diameter of the support ring on the top neck. Set to 0 for no ring. Default: 33
-//   thread_pitch1 = Thread pitch of top neck.
+//   thread_pitch1 = Thread pitch of top neck. Default: 2.7
 //   neck_od2 = Outer diameter of bottom neck w/o threads.  Leave undefined to duplicate neck_od1
 //   neck_id2 = Inner diameter of bottom neck.  Leave undefined to duplicate neck_id1
 //   thread_od2 = Outer diameter of threads on bottom neck.  Leave undefined to duplicate thread_od1
@@ -933,7 +933,7 @@ module bottle_adapter_neck_to_neck(
     thread_od1 = 27.6,
     height1 = 17,
     support_od1 = 33,
-    thread_pitch1 = 3.18,
+    thread_pitch1 = 2.7,
     neck_od2, neck_id2,
     thread_od2, height2,
     support_od2,  pitch2,

--- a/bottlecaps.scad
+++ b/bottlecaps.scad
@@ -1,24 +1,24 @@
 //////////////////////////////////////////////////////////////////////
 // LibFile: bottlecaps.scad
-//   Bottle caps and necks for PCO18XX standard plastic beverage bottles, and SPI standard bottle necks.  
+//   Caps and necks for PCO18XX standard plastic beverage bottles, SPI bottles and jars, and mason jars.
 // Includes:
 //   include <BOSL2/std.scad>
 //   include <BOSL2/bottlecaps.scad>
 // FileGroup: Threaded Parts
-// FileSummary: Standard bottle caps and necks.
+// FileSummary: Standard bottle/jar caps and necks, and garden hose threads.
 //////////////////////////////////////////////////////////////////////
-
 
 _BOSL2_BOTTLECAPS = is_undef(_BOSL2_STD) && (is_undef(BOSL2_NO_STD_WARNING) || !BOSL2_NO_STD_WARNING) ?
        echo("Warning: bottlecaps.scad included without std.scad; dependencies may be missing\nSet BOSL2_NO_STD_WARNING = true to mute this warning.") true : true;
-
-
 
 include <threading.scad>
 include <structs.scad>
 include <rounding.scad>
 
 // Section: PCO-1810 Bottle Threading
+//   The PCO (Plastic Closure Only) 1810 is a bottle neck standard for water and drink bottles typically ranging from 250 ml to 2 L.
+//   PCO1810 is the original specification, using a 21 mm thread height, 810° thread travel, and 3.18 mm thread pitch. An [updated standard PCO1881](bottlecaps.scad#section-pco-1881-bottle-threading) uses a shorter neck and thinner threads to save material.
+// Both standards have a neck diameter of 28 mm.
 
 
 // Module: pco1810_neck()
@@ -35,7 +35,7 @@ include <rounding.scad>
 //   ---
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Named Anchors:
 //   "tamper-ring" = Centered at the top of the anti-tamper ring channel.
 //   "support-ring" = Centered at the bottom of the support ring.
@@ -164,7 +164,7 @@ function  pco1810_neck(wall=2, anchor="support-ring", spin=0, orient=UP) =
 //   ---
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin. See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Named Anchors:
 //   "inside-top" = Centered on the inside top of the cap.
 // Examples:
@@ -224,6 +224,8 @@ function pco1810_cap(h, r, d, wall, texture="none", anchor=BOTTOM, spin=0, orien
 
 
 // Section: PCO-1881 Bottle Threading
+//   The PCO (Plastic Closure Only) 1881 standard is an update to the [PCO1810](bottlecaps.scad#section-pco-1810-bottle-threading). Both are used for plastic water and drink bottles typically ranging from 250 ml to 2 L. Both standards have a neck diameter of 28 mm.
+//   Because the neck and cap account for a large fraction of the total material used in a plastic bottle, the PCO1881 standard was developed to reduce material compared to the PCO1810 standard by using a shorter neck (17 mm thread height) and thinner threads (650° thread travel with 2.7 mm pitch).
 
 
 // Module: pco1881_neck()
@@ -240,7 +242,7 @@ function pco1810_cap(h, r, d, wall, texture="none", anchor=BOTTOM, spin=0, orien
 //   ---
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Named Anchors:
 //   "tamper-ring" = Centered at the top of the anti-tamper ring channel.
 //   "support-ring" = Centered at the bottom of the support ring.
@@ -262,7 +264,7 @@ module pco1881_neck(wall=2, anchor="support-ring", spin=0, orient=UP)
     support_rad = 0.30;
     support_h = 17.00;
     support_ang = 15;
-    tamper_ring_d = 28.00;
+    tamper_ring_d = 33;
     tamper_ring_width = 0.30;
     tamper_ring_ang = 45;
     tamper_base_d = 25.71;
@@ -366,7 +368,7 @@ function pco1881_neck(wall=2, anchor="support-ring", spin=0, orient=UP) =
 //   ---
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Named Anchors:
 //   "inside-top" = Centered on the inside top of the cap.
 // Examples:
@@ -413,6 +415,8 @@ function pco1881_cap(wall=2, texture="none", anchor=BOTTOM, spin=0, orient=UP) =
 
 
 // Section: Generic Bottle Connectors
+//    All of these connectors default to the PCO1881 standard, if applicable, for arguments that are left blank.
+
 
 // Module: generic_bottle_neck()
 // Synopsis: Creates a generic neck for a bottle.
@@ -426,28 +430,28 @@ function pco1881_cap(wall=2, texture="none", anchor=BOTTOM, spin=0, orient=UP) =
 // Arguments:
 //   wall = distance between ID and any wall that may be below the support
 //   ---
-//   neck_d = Outer diameter of neck without threads
-//   id = Inner diameter of neck
-//   thread_od = Outer diameter of thread
-//   height = Height of neck above support
-//   support_d = Outer diameter of support ring.  Set to 0 for no support.
-//   pitch = Thread pitch
-//   round_supp = True to round the lower edge of the support ring
-//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   neck_d = Outer diameter of neck without threads. Default: 26.19
+//   id = Inner diameter of neck. Default: 21.74
+//   thread_od = Outer diameter of thread. Default: 27.4
+//   height = Height of neck above support. Default: 17
+//   support_d = Outer diameter of support ring. Set to 0 for no support. Default: 33
+//   pitch = Thread pitch. Default: 2.7
+//   round_supp = True to round the lower edge of the support ring. Default: false
+//   anchor = Translate so anchor point is at origin (0,0,0). See [anchor](attachments.scad#subsection-anchor).  Default: `"support-ring"`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: 0
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Named Anchors:
 //   "support-ring" = Centered at the bottom of the support ring.
 // Example:
 //   generic_bottle_neck();
 module generic_bottle_neck(
     wall,
-    neck_d = 25,
-    id = 21.4,
-    thread_od = 27.2,
+    neck_d = 26.19,
+    id = 21.74,
+    thread_od = 27.4,
     height = 17,
-    support_d = 33.0,
-    pitch = 3.2,
+    support_d = 33,
+    pitch = 2.7,
     round_supp = false,
     anchor = "support-ring",
     spin = 0,
@@ -458,7 +462,7 @@ module generic_bottle_neck(
     supp_d = max(neck_d, support_d);
     thread_pitch = pitch;
     flank_angle = 15;
-
+   
     diamMagMult = neck_d / 26.19;
     heightMagMult = height / 17.00;
 
@@ -467,7 +471,7 @@ module generic_bottle_neck(
     support_r = floor(((supp_d == neck_d) ? sup_r : min(sup_r, (supp_d - neck_d) / 2)) * 5000) / 10000;
     support_rad = (wall == undef || !round_supp) ? support_r :
         min(support_r, floor((supp_d - (inner_d + 2 * wall)) * 5000) / 10000);
-        //Too small of a radius will cause errors with the arc, this limits granularity to .0001mm
+        //Too small of a radius causes errors with the arc; this limits granularity to .0001mm
     support_width = max(heightMagMult,1) * sign(support_d);
     roundover = 0.58 * diamMagMult;
     lip_roundover_r = (roundover > (neck_d - inner_d) / 2) ? 0 : roundover;
@@ -552,22 +556,22 @@ function generic_bottle_neck(
 // Usage:
 //   generic_bottle_cap(wall, [texture], ...) [ATTACHMENTS];
 // Description:
-//   Creates a basic threaded cap given specifications.  You must give exactly two of `thread_od`, `neck_od` and `thread_depth` to
-//   specify the thread geometry.  Note that most glass bottles conform to the SPI standard and caps for them may be more easily produced using {{sp_cap()}}.
+//   Creates a basic threaded cap given specifications. You must give exactly two of `thread_od`, `neck_od` and `thread_depth` to
+//   specify the thread geometry. Most glass bottles conform to the SPI standard and caps for them may be more easily produced using {{sp_cap()}}.
 // Arguments:
 //   wall = Wall thickness.  Default: 2
 //   texture = The surface texture of the cap.  Valid values are "none", "knurled", or "ribbed".  Default: "none"
 //   ---
-//   height = Interior height of the cap
-//   thread_od = Outer diameter of the threads
-//   neck_od = Outer diameter of neck
-//   thread_depth = Depth of the threads 
-//   tolerance = Extra space to add to the outer diameter of threads and neck.  Applied to radius.  Default: 0.2
-//   flank_angle = Angle of taper on threads.  Default: 15
-//   pitch = Thread pitch.  Default: 4
-//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   height = Interior height of the cap. Default: 11.2
+//   thread_od = Outer diameter of the threads. Default: 25.1
+//   neck_od = Outer diameter of neck. Default: undef
+//   thread_depth = Depth of the threads. Default: 1.6
+//   tolerance = Extra space to add to the outer diameter of threads and neck. Applied to radius. Default: 0.2
+//   flank_angle = Angle of taper on threads. Default: 15
+//   pitch = Thread pitch. Default: 2.7
+//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `BOTTOM`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: 0
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Named Anchors:
 //   "inside-top" = Centered on the inside top of the cap.
 // Examples:
@@ -577,13 +581,13 @@ function generic_bottle_neck(
 module generic_bottle_cap(
     wall = 2,
     texture = "none",
-    height,
-    thread_depth,
-    thread_od, 
-    tolerance = .2,
+    height = 11.2,
+    thread_depth = 1.6,
+    thread_od = 25.1,
+    tolerance = 0.2,
     neck_od,
     flank_angle = 15,
-    pitch = 4,
+    pitch = 2.7,
     anchor = BOTTOM,
     spin = 0,
     orient = UP
@@ -640,7 +644,7 @@ function generic_bottle_cap(
 
 
 // Module: bottle_adapter_neck_to_cap()
-// Synopsis: Creates a generic adaptor between a neck and a cap.
+// Synopsis: Creates a generic adapter between a neck and a cap.
 // SynTags: Geom
 // Topics: Bottles, Threading
 // See Also: bottle_adapter_neck_to_neck()
@@ -651,25 +655,25 @@ function generic_bottle_cap(
 // Arguments:
 //   wall = Thickness of wall between neck and cap when d=0.  Leave undefined to have the outside of the tube go from the OD of the neck support ring to the OD of the cap.  Default: undef
 //   texture = The surface texture of the cap.  Valid values are "none", "knurled", or "ribbed".  Default: "none"
-//   cap_wall = Wall thickness of the cap in mm.
-//   cap_h = Interior height of the cap in mm.
-//   cap_thread_depth = Cap thread depth.  Default: 2.34
-//   tolerance = Extra space to add to the outer diameter of threads and neck in mm.  Applied to radius.
-//   cap_neck_od = Inner diameter of the cap threads.
-//   cap_neck_id = Inner diameter of the hole through the cap.
-//   cap_thread_taper = Angle of taper on threads.
-//   cap_thread_pitch = Thread pitch in mm
-//   neck_d = Outer diameter of neck w/o threads
-//   neck_id = Inner diameter of neck
-//   neck_thread_od = 27.2
-//   neck_h = Height of neck down to support ring
-//   neck_thread_pitch = Thread pitch in mm.
+//   cap_wall = Wall thickness of the cap in mm. Default: 2
+//   cap_h = Interior height of the cap in mm. Default: 11.2
+//   cap_thread_depth = Cap thread depth.  Default: 1.6
+//   tolerance = Extra space to add to the outer diameter of threads and neck in mm.  Applied to radius. Default: 0.2
+//   cap_neck_od = Inner diameter of the cap threads. Default: 25.5
+//   cap_neck_id = Inner diameter of the hole through the cap. Default: undef
+//   cap_thread_taper = Angle of taper on threads. Default: 15
+//   cap_thread_pitch = Thread pitch in mm. Default: 2.7
+//   neck_d = Outer diameter of neck w/o threads. Default: 24.8
+//   neck_id = Inner diameter of neck. Default: 21.4
+//   neck_thread_od = Outer diameter of neck with threads. Default: 27.6
+//   neck_h = Height of neck down to support ring. Default: 17
+//   neck_thread_pitch = Thread pitch in mm. Default: 2.7
 //   neck_support_od = Outer diameter of neck support ring.  Leave undefined to set equal to OD of cap.  Set to 0 for no ring.  Default: undef
-//   d = Distance between bottom of neck and top of cap
-//   taper_lead_in = Length to leave straight before tapering on tube between neck and cap if exists.
+//   d = Distance between bottom of neck and top of cap. Default: 0
+//   taper_lead_in = Length to leave straight before tapering on tube between neck and cap if exists. Default: 0
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Examples:
 //   bottle_adapter_neck_to_cap();
 module bottle_adapter_neck_to_cap(
@@ -677,20 +681,20 @@ module bottle_adapter_neck_to_cap(
     texture = "none",
     cap_wall = 2,
     cap_h = 11.2,
-    cap_thread_depth = 2.34,
-    tolerance = .2,
+    cap_thread_depth = 1.6,
+    tolerance = 0.2,
     cap_neck_od = 25.5,
     cap_neck_id,
     cap_thread_taper = 15,
-    cap_thread_pitch = 4,
-    neck_d = 25,
+    cap_thread_pitch = 2.7,
+    neck_d = 24.8,
     neck_id = 21.4,
-    neck_thread_od = 27.2,
+    neck_thread_od = 27.6,
     neck_h = 17,
-    neck_thread_pitch = 3.2,
+    neck_thread_pitch = 2.7,
     neck_support_od,
     d = 0,
-    taper_lead_in = 0, anchor, spin,orient
+    taper_lead_in = 0, anchor=CENTER, spin=0, orient=UP
 ) {
     cap_od = cap_neck_od + 2*(cap_thread_depth - 0.8) + 2 * tolerance;
     neck_support_od = (neck_support_od == undef || (d == 0 && neck_support_od < cap_od)) ? cap_od+2*cap_wall
@@ -779,11 +783,11 @@ function bottle_adapter_neck_to_cap(
 // Arguments:
 //   wall = Wall thickness in mm.
 //   texture = The surface texture of the cap.  Valid values are "none", "knurled", or "ribbed".  Default: "none"
-//   cap_h1 = Interior height of top cap.
-//   cap_thread_depth1 = Thread depth on top cap.  Default: 2.34
-//   tolerance = Extra space to add to the outer diameter of threads and neck in mm.  Applied to radius.
-//   cap_neck_od1 = Inner diameter of threads on top cap.
-//   cap_thread_pitch1 = Thread pitch of top cap in mm.
+//   cap_h1 = Interior height of top cap. Default: 11.2
+//   cap_thread_depth1 = Thread depth on top cap. Default: 1.6
+//   tolerance = Extra space to add to the outer diameter of threads and neck in mm. Applied to radius. Default: 0.2
+//   cap_neck_od1 = Inner diameter of threads on top cap. Default: 25.5
+//   cap_thread_pitch1 = Thread pitch of top cap in mm. Default: 2.7
 //   cap_h2 = Interior height of bottom cap.  Leave undefined to duplicate cap_h1.
 //   cap_thread_depth2 = Thread depth on bottom cap.  Default: same as cap_thread_depth1
 //   cap_neck_od2 = Inner diameter of threads on top cap.  Leave undefined to duplicate cap_neck_od1.
@@ -794,17 +798,17 @@ function bottle_adapter_neck_to_cap(
 //   taper_lead_in = Length to leave straight before tapering on tube between caps if exists.
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Examples:
 //   bottle_adapter_cap_to_cap();
 module bottle_adapter_cap_to_cap(
     wall = 2,
     texture = "none",
     cap_h1 = 11.2,
-    cap_thread_depth1 = 2.34,
-    tolerance = .2,
+    cap_thread_depth1 = 1.6,
+    tolerance = 0.2,
     cap_neck_od1 = 25.5,
-    cap_thread_pitch1 = 4,
+    cap_thread_pitch1 = 2.7,
     cap_h2,
     cap_thread_depth2,
     cap_neck_od2,
@@ -820,14 +824,13 @@ module bottle_adapter_cap_to_cap(
     taper_lead_in = (d >= taper_lead_in * 2) ? taper_lead_in : d / 2;
 
     neck_id = min(cap_neck_od1 - cap_thread_depth1, cap_neck_od2-cap_thread_depth2);
-    
+
     top_h = cap_h1+wall;
     bot_h = cap_h2+wall;
-    
 
     cap_od1 = cap_neck_od1 + 2*(cap_thread_depth1 - 0.8) + 2 * tolerance;   // WTF; Engineered for consistency with old code, but
     cap_od2 = cap_neck_od2 + 2*(cap_thread_depth2 - 0.8) + 2 * tolerance;   // WTF; Engineered for consistency with old code, but 
-    
+
     $fn = segs(33 / 2);
     attachable(anchor=anchor,spin=spin,orient=orient, h=top_h+bot_h+d, d=max(cap_od1,cap_od2)+2*wall){
       zmove((bot_h-top_h)/2)
@@ -903,12 +906,12 @@ function bottle_adapter_cap_to_cap(
 //   Creates a threaded neck to neck adapter.
 // Arguments:
 //   ---
-//   d = Distance between bottoms of necks
-//   neck_od1 = Outer diameter of top neck w/o threads
-//   neck_id1 = Inner diameter of top neck
-//   thread_od1 = Outer diameter of threads on top neck
-//   height1 =  Height of top neck above support ring.
-//   support_od1 = Outer diameter of the support ring on the top neck.  Set to 0 for no ring.
+//   d = Distance between bottoms of necks. Default: 0
+//   neck_od1 = Outer diameter of top neck without threads. Default: 24.8
+//   neck_id1 = Inner diameter of top neck. Default 21.4
+//   thread_od1 = Outer diameter of threads on top neck. Default: 27.4
+//   height1 =  Height of top neck above support ring. Default: 17
+//   support_od1 = Outer diameter of the support ring on the top neck. Set to 0 for no ring. Default: 33
 //   thread_pitch1 = Thread pitch of top neck.
 //   neck_od2 = Outer diameter of bottom neck w/o threads.  Leave undefined to duplicate neck_od1
 //   neck_id2 = Inner diameter of bottom neck.  Leave undefined to duplicate neck_id1
@@ -920,17 +923,17 @@ function bottle_adapter_cap_to_cap(
 //   wall = Thickness of tube wall between necks.  Leave undefined to match outer diameters with the neckODs/supportODs.
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Examples:
 //   bottle_adapter_neck_to_neck();
 module bottle_adapter_neck_to_neck(
     d = 0,
-    neck_od1 = 25,
+    neck_od1 = 24.8,
     neck_id1 = 21.4,
-    thread_od1 = 27.2,
+    thread_od1 = 27.6,
     height1 = 17,
-    support_od1 = 33.0,
-    thread_pitch1 = 3.2,
+    support_od1 = 33,
+    thread_pitch1 = 3.18,
     neck_od2, neck_id2,
     thread_od2, height2,
     support_od2,  pitch2,
@@ -1037,26 +1040,25 @@ function bottle_adapter_neck_to_neck(
 // Usage:
 //   sp_neck(diam, type, wall|id=, [style=], [bead=]) [ATTACHMENTS];
 // Description:
-//   Make a SPI (Society of Plastics Industry) threaded bottle neck.  You must
+//   Make a SPI (Society of Plastics Industry) threaded bottle or jar neck. You must
 //   supply the nominal outer diameter of the threads and the thread type, one of
-//   400, 410 and 415.  The 400 type neck has 360 degrees of thread, the 410
-//   neck has 540 degrees of thread, and the 415 neck has 720 degrees of thread.
-//   You can also choose between the L style thread, which is symmetric and
-//   the M style thread, which is an asymmetric buttress thread.  The M style
-//   may be good for 3d printing if printed with the flat face up.  
+//   400, 410 and 415. The 400 type neck has 360° of thread, the 410
+//   neck has 540° of thread, and the 415 neck has 720° of thread.
+//   You can also choose between the symmetric L style thread and the asymmetric
+//   M style buttress thread.  The M style may be good for 3d printing if printed with the flat face up.  
 //   You can specify the wall thickness (measured from the base of the threads) or
 //   the inner diameter, and you can specify an optional bead at the base of the threads.
 // Arguments:
 //   diam = nominal outer diameter of threads
-//   type = thread type, one of 400, 410 and 415
+//   type = thread type, one of 400, 410, and 415
 //   wall = wall thickness
 //   ---
 //   id = inner diameter
 //   style = Either "L" or "M" to specify the thread style.  Default: "L"
-//   bead = if true apply a bad to the neck.  Default: false
+//   bead = if true apply a bead to the neck.  Default: false
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Examples:
 //   sp_neck(48,400,2);
 //   sp_neck(48,400,2,bead=true);
@@ -1170,12 +1172,12 @@ function _sp_thread_profile(tpi, a, S, style, flip=false) =
 function sp_neck(diam,type,wall,id,style="L",bead=false, anchor, spin, orient) = no_function("sp_neck");
 module sp_neck(diam,type,wall,id,style="L",bead=false, anchor, spin, orient)
 {
-    assert(num_defined([wall,id])==1, "Must define exactly one of wall and id");
+    assert(num_defined([wall,id])==1, "\nMust define exactly one of wall and id.");
     
     table = struct_val(_sp_specs,type);
-    dum1=assert(is_def(table),"Unknown SP closure type.  Type must be one of 400, 410, or 415");
+    dum1=assert(is_def(table),"\nUnknown SP closure type.  Type must be one of 400, 410, or 415.");
     entry = struct_val(table, diam);
-    dum2=assert(is_def(entry), str("Unknown closure nominal diameter.  Allowed diameters for SP",type,": ",struct_keys(table)))
+    dum2=assert(is_def(entry), str("\nUnknown closure nominal diameter. Allowed diameters for SP",type,": ",struct_keys(table)))
          assert(style=="L" || style=="M", "style must be \"L\" or \"M\"");
 
     T = entry[0];
@@ -1241,23 +1243,23 @@ module sp_neck(diam,type,wall,id,style="L",bead=false, anchor, spin, orient)
 // Usage:
 //   sp_cap(diam, type, wall, [style=], [top_adj=], [bot_adj=], [texture=], [$slop]) [ATTACHMENTS];
 // Description:
-//   Make a SPI (Society of Plastics Industry) threaded bottle neck.  You must
+//   Make a SPI (Society of Plastics Industry) threaded bottle or jar cap. You must
 //   supply the nominal outer diameter of the threads and the thread type, one of
-//   400, 410 and 415.  The 400 type neck has 360 degrees of thread, the 410
-//   neck has 540 degrees of thread, and the 415 neck has 720 degrees of thread.
-//   You can also choose between the L style thread, which is symmetric and
-//   the M style thread, which is an asymmetric buttress thread.  Note that it
-//   is OK to mix styles, so you can put an L-style cap onto an M-style neck.  
+//   400, 410 and 415. The 400 type neck has 360° of thread, the 410
+//   neck has 540° of thread, and the 415 neck has 720° of thread.
+//   You can also choose between the symmetric L style thread and
+//   the asymmetric M style buttress thread.
+//   It is OK to mix styles, so you can put an L-style cap onto an M-style neck.  
 //   .
-//   The 410 and 415 caps have very long unthreaded sections at the bottom.
+//   The 410 and 415 caps have long unthreaded sections at the bottom.
 //   The bot_adj parameter specifies an amount to reduce that bottom extension, which might be
 //   necessary if the cap bottoms out on the bead.  Be careful that you don't shrink past the threads,
-//   especially if making adjustments to 400 caps which have a very small bottom extension.  
+//   especially if making adjustments to 400 caps that have a small bottom extension.  
 //   These caps often contain a cardboard or foam sealer disk, which can be as much as 1mm thick, and
 //   would cause the cap to stop in a higher position.
 //   .
-//   You can also adjust the space between the top of the cap and the threads using top_adj.  This
-//   will change how the threads engage when the cap is fully seated.
+//   You can also adjust the space between the top of the cap and the threads using top_adj. This
+//   changes how the threads engage when the cap is fully seated.
 //   .
 //   The inner diameter of the cap is set to allow 10% of the thread depth in clearance.  The diameter
 //   is further increased by `2 * $slop` so you can increase clearance if necessary. 
@@ -1267,7 +1269,7 @@ module sp_neck(diam,type,wall,id,style="L",bead=false, anchor, spin, orient)
 //   find ways that it does the wrong thing, file a report.  
 // Arguments:
 //   diam = nominal outer diameter of threads
-//   type = thread type, one of 400, 410 and 415
+//   type = thread type, one of 400, 410, or 415
 //   wall = wall thickness
 //   ---
 //   style = Either "L" or "M" to specify the thread style.  Default: "L"
@@ -1277,7 +1279,7 @@ module sp_neck(diam,type,wall,id,style="L",bead=false, anchor, spin, orient)
 //   $slop = Increase inner diameter by `2 * $slop`.  
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Examples:
 //   sp_cap(48,400,2);
 //   sp_cap(22,400,2);
@@ -1286,9 +1288,9 @@ module sp_neck(diam,type,wall,id,style="L",bead=false, anchor, spin, orient)
 module sp_cap(diam,type,wall,style="L",top_adj=0, bot_adj=0, texture="none", anchor, spin, orient)
 {
     table = struct_val(_sp_specs,type);
-    dum1=assert(is_def(table),"Unknown SP closure type.  Type must be one of 400, 410, or 415");
+    dum1=assert(is_def(table),"\nUnknown SP closure type. Type must be one of 400, 410, or 415");
     entry = struct_val(table, diam);
-    dum2=assert(is_def(entry), str("Unknown closure nominal diameter.  Allowed diameters for SP",type,": ",struct_keys(table)))
+    dum2=assert(is_def(entry), str("\nUnknown closure nominal diameter. Allowed diameters for SP",type,": ",struct_keys(table)))
          assert(style=="L" || style=="M", "style must be \"L\" or \"M\"");
 
     T = entry[0];
@@ -1300,7 +1302,7 @@ module sp_cap(diam,type,wall,style="L",top_adj=0, bot_adj=0, texture="none", anc
 
     twist = struct_val(_sp_twist, type);
 
-    dum3=assert(top_adj<S+0.75*a, str("The top_adj value is too large so the thread won't fit.  It must be smaller than ",S+0.75*a));
+    dum3=assert(top_adj<S+0.75*a, str("\nThe top_adj value is too large so the thread cannot fit. It must be smaller than ",S+0.75*a));
     oprofile = _sp_thread_profile(tpi,a,S+0.75*a-top_adj,style,flip=true);
     bounds=pointlist_bounds(oprofile);
     profile = fwd(-bounds[0].y,yflip(oprofile));
@@ -1330,7 +1332,6 @@ module sp_cap(diam,type,wall,style="L",top_adj=0, bot_adj=0, texture="none", anc
 }
 
 
-
 // Function: sp_diameter()
 // Synopsis: Returns the base diameter of an SPI bottle neck from the nominal diameter and type number.
 // Topics: Bottles, Threading
@@ -1346,13 +1347,254 @@ function sp_diameter(diam,type) =
   let(
       table = struct_val(_sp_specs,type)
   )
-  assert(is_def(table),"Unknown SP closure type.  Type must be one of 400, 410, or 415")
+  assert(is_def(table),"\nUnknown SP closure type. Type must be one of 400, 410, or 415.")
   let(
       entry = struct_val(table, diam)
   )
-  assert(is_def(entry), str("Unknown closure nominal diameter.  Allowed diameters for SP",type,": ",struct_keys(table)))
+  assert(is_def(entry), str("\nUnknown closure nominal diameter. Allowed diameters for SP",type,": ",struct_keys(table)))
   entry[0];
 
+
+
+// Section: Mason Jar Threading
+//   The Mason jar is a glass container with a threaded neck and two-piece metal lid consisting of a sealing disk and a threaded retaining ring. It has been widely used in North America since it was patented in 1858 by American tinsmith John Landis Mason.
+//   Brands like Ball and Kerr established the two dominant thread geometries still in use today: 70-450G (standard glass Mason jar with 70 mm outer thread diameter) and 86-400 (wide mouth Mason jar with 86 mm outer thread diameter). The 450G designation has a taller thread engagement area compared to the 400 series.
+//   One may also run across a 70-400 thread finish designed for plastic caps (different from the SPI 70-400), and the 89-400 finish used by some international suppliers.
+//   .
+//   The Glass Packaging Institute (GPI) maintains standards and drawings for Mason jar threads, but does not make them publicly available. The specs used in these modules were derived from various online sources and physical measurements.
+
+
+// Module: mason_neck()
+// Synopsis: Creates a threaded glass mason jar neck.
+// SynTags: Geom
+// Topics: Bottles, Threading
+// See Also: mason_cap()
+// Usage:
+//   mason_neck(diam, type, wall|id=, [style=], [bead=]) [ATTACHMENTS];
+// Description:
+//   Make a threaded Mason jar neck. You must
+//   supply the nominal outer diameter of the threads and the thread type,
+//   400 or 450. The 400 type neck is generated with 370° of thread, and the 450
+//   neck has 460° of thread (slightly more than 1.25 turns).
+//   You can also choose between the symmetric L style thread and the asymmetric
+//   M style buttress thread.  The M style may be good for 3d printing if printed with the flat face up.  
+//   You can specify the wall thickness (measured from the base of the threads) or
+//   the inner diameter, and you can specify an optional bead at the base of the threads.
+// Arguments:
+//   diam = nominal outer diameter of threads
+//   type = thread type, 400 or 450
+//   wall = wall thickness
+//   ---
+//   id = inner diameter
+//   style = Either "L" or "M" to specify the thread style.  Default: "L"
+//   bead = if true apply a bead to the neck.  Default: false
+//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+// Examples:
+//   mason_neck(70,400,2);
+//   mason_neck(70,450,2,bead=true);
+//   mason_neck(86,400,2);
+//   mason_neck(89,400,2,style="M",bead=true);
+
+
+//  T = peak to peak diameter (outer diameter)
+//  I = Inner diameter
+//  S = space above top thread
+//  H = total height of neck
+
+_gl_specs = [ // specs for glass mason jars (derived from various online sources)
+  [400, //diam     T      I     H   S  tpi
+        [[ 70, [ 69.85, 64.5,  17,  3,  4]],
+         [ 86, [ 85.85, 79.5,  17,  3,  4]],
+         [ 89, [ 88.9,  82.5,  19,  3,  5]]
+        ]],
+  [450, //diam     T      I      H     S    tpi
+        [[ 70, [ 69.85, 64.5,    22,   3,   4]]
+        ]]
+];
+
+_gl_twist = [ [400, 370],   // for 70/86/89-400 glass jars
+              [450, 460]    // for 70-450G glass jars
+            ];
+
+
+// profile data: tpi, total width, depth, 
+_gl_thread_width = [
+                [4, 3.6],
+                [5, 3.6]
+    ];
+
+
+function _gl_thread_profile(tpi, a, S, style, flip=false) = 
+    let(
+        pitch = 1/tpi*INCH,
+        cL = a*(1-1/sqrt(3)),
+        cM = (1-tan(10))*a/2,
+        roundings = style=="L" ? 0.5 
+                  : [0.25, 0.25, 0.75, 0.75],
+        path1 = style=="L"
+                  ? round_corners([[-1/2*pitch,-a/2],
+                                   [-a/2,-a/2],
+                                   [-cL/2,0],
+                                   [cL/2,0],
+                                   [a/2,-a/2],
+                                   [1/2*pitch,-a/2]], radius=roundings, closed=false,$fn=24)
+                  : round_corners(
+                       [[-1/2*pitch,-a/2],
+                                   [-a/2, -a/2],
+                                   [-cM, 0],
+                                   [0,0],
+                                   [a/2,-a/2],
+                                   [1/2*pitch,-a/2]], radius=roundings, closed=false, $fn=24),
+        path2 = flip ? reverse(xflip(path1)) : path1
+   )
+   // Shift so that the profile is S mm from the right end to create proper length S top gap
+   select(right(-a/2+1/2-S,p=path2),1,-2)/pitch;
+
+
+
+function mason_neck(diam,type,wall,id,style="L",bead=false, anchor, spin, orient) = no_function("mason_neck");
+module mason_neck(diam,type,wall,id,style="L",bead=false, anchor, spin, orient)
+{
+    assert(num_defined([wall,id])==1, "\nMust define exactly one of wall and id.");
+    
+    table = struct_val(_gl_specs,type);
+    dum1=assert(is_def(table),"\nUnknown glass jar closure type. Type must be 400 or 450.");
+    entry = struct_val(table, diam);
+    dum2=assert(is_def(entry), str("\nUnknown closure nominal diameter. Allowed diameters for glass ",type,": ",struct_keys(table)))
+         assert(style=="L" || style=="M", "style must be \"L\" or \"M\"");
+
+    T = entry[0];
+    I = entry[1];
+    H = entry[2];
+    S = entry[3];
+    tpi = entry[4];
+
+    a = struct_val(_gl_thread_width,tpi);
+    twist = struct_val(_gl_twist, type);
+    profile = _sp_thread_profile(tpi,a,S,style);
+    depth = a/2;
+    taperlen = 2*a;
+    beadmax = type==400 ? (T/2-depth)+depth*1.25
+            : diam <=15 ? (T-.15)/2 : (T-.05)/2;
+    W = a*1.5;      // arbitrary decision
+    beadpts = [
+                [0,-W/2],
+                each arc(16, points = [[T/2-depth, -W/2],
+                                       [beadmax, 0],
+                                       [T/2-depth, W/2]]),
+                [0,W/2]
+              ];
+
+    attachable(anchor,spin,orient,r=bead ? beadmax : T/2, l=H){
+        up(H/2){
+            difference(){
+                union(){
+                    thread_helix(d=T-.01, profile=profile, pitch = INCH/tpi, turns=twist/360, lead_in=taperlen, anchor=TOP);
+                    cylinder(d=T-depth*2,h=H,anchor=TOP);
+                    if (bead)
+                      down(H)
+                         rotate_extrude()
+                            polygon(beadpts);
+                }
+                up(.5)cyl(d=is_def(id) ? id : T-a-2*wall, l=H+1, anchor=TOP);
+            }
+        }
+        children();
+    }
+}
+
+
+// Module: mason_cap()
+// Synopsis: Creates a threaded mason jar cap.
+// SynTags: Geom
+// Topics: Bottles, Threading
+// See Also: mason_neck()
+// Usage:
+//   mason_cap(diam, type, wall, [style=], [top_adj=], [bot_adj=], [texture=], [$slop]) [ATTACHMENTS];
+// Description:
+//   Make a GPI (Glass Packaging Institute) threaded mason jar cap. You must
+//   supply the nominal outer diameter of the threads and the thread type, 
+//   400 or 450. While the 400 type neck has 370° of thread, and the 450
+//   neck has 460° of thread, the cap thread is increased by 1.35 times.
+//   You can also choose between the symmetric L style thread and the asymmetric
+//   M style buttress thread.  The M style may be good for 3d printing if printed with the flat face up.  
+//   It is OK to mix styles, so you can put an L-style cap onto an M-style neck.  
+//   .
+//   The bot_adj parameter specifies an amount to reduce that bottom extension, which might be
+//   necessary if the cap bottoms out on the bead.  Be careful that you don't shrink past the threads,
+//   especially if making adjustments to 400 caps that have a small bottom extension.  
+//   These caps often contain a cardboard or foam sealer disk, which can be as much as 1mm thick, and
+//   would cause the cap to stop in a higher position.
+//   .
+//   You can also adjust the space between the top of the cap and the threads using top_adj. This
+//   changes how the threads engage when the cap is fully seated.
+//   .
+//   The inner diameter of the cap is set to allow 10% of the thread depth in clearance.  The diameter
+//   is further increased by `2 * $slop` so you can increase clearance if necessary. 
+// Arguments:
+//   diam = nominal outer diameter of threads
+//   type = thread type, 400 or 450
+//   wall = wall thickness
+//   ---
+//   style = Either "L" or "M" to specify the thread style.  Default: "L"
+//   top_adj = Amount to reduce top space in the cap, which means it doesn't screw down as far.  Default: 3
+//   bot_adj = Amount to reduce extension of cap at the bottom, which also means it doesn't screw down as far.  Default: 0
+//   texture = texture for outside of cap, one of "knurled", "ribbed" or "none.  Default: "none"
+//   $slop = Increase inner diameter by `2 * $slop`.  
+//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+// Examples:
+//   mason_cap(70,450,2);
+//   mason_cap(86,400,2);
+
+function mason_cap(diam,type,wall,style="L",top_adj=3, bot_adj=0, texture="none", anchor, spin, orient) = no_function("mason_cap");
+module mason_cap(diam,type,wall,style="L",top_adj=3, bot_adj=0, texture="none", anchor, spin, orient)
+{
+    table = struct_val(_gl_specs,type);
+    dum1=assert(is_def(table),"\nUnknown glass jar closure type. Type must be 400 or 450.");
+    entry = struct_val(table, diam);
+    dum2=assert(is_def(entry), str("\nUnknown closure nominal diameter. Allowed diameters for glass ",type,": ",struct_keys(table)))
+         assert(style=="L" || style=="M", "\nstyle must be \"L\" or \"M\"");
+
+    T = entry[0];
+    I = entry[1];
+    H = entry[2]-0.5;
+    S = entry[3];
+    tpi = entry[4];
+    a = struct_val(_gl_thread_width,tpi);
+    twist = struct_val(_gl_twist, type) * 1.35;
+
+    dum3=assert(top_adj<S+0.75*a, str("\nThe top_adj value is too large so the thread cannot fit. It must be smaller than ",S+0.75*a));
+    oprofile = _sp_thread_profile(tpi,a,S+0.75*a-top_adj,style,flip=true);
+    bounds=pointlist_bounds(oprofile);
+    profile = fwd(-bounds[0].y,yflip(oprofile));
+
+    depth = a/2;
+    taperlen = 2*a;
+    assert(in_list(texture, ["none","knurled","ribbed"]));
+    space=2*depth/10+2*get_slop();
+    attachable(anchor,spin,orient,r= (T+space)/2+wall, l=H-bot_adj+wall){
+        xrot(180)
+        up((H-bot_adj)/2-wall/2){
+            difference(){
+                up(wall){
+                   if (texture=="knurled")
+                        cyl(d=T+space+2*wall,l=H+wall-bot_adj,anchor=TOP,texture="trunc_pyramids", tex_size=[3,3], style="convex");
+                   else if (texture == "ribbed") 
+                        cyl(d=T+space+2*wall,l=H+wall-bot_adj,anchor=TOP,chamfer2=.8,tex_taper=0,texture="trunc_ribs", tex_size=[3,3], style="min_edge");
+                   else
+                        cyl(d=T+space+2*wall,l=H+wall-bot_adj,anchor=TOP,chamfer2=.8);
+                }
+                cyl(d=T+space, l=H-bot_adj+1, anchor=TOP);
+            }
+            thread_helix(d=T+space-.01, profile=profile, pitch = INCH/tpi, turns=twist/360, lead_in=taperlen, anchor=TOP, internal=true);
+        }
+        children();
+    }
+}
 
 
 // vim: expandtab tabstop=4 shiftwidth=4 softtabstop=4 nowrap

--- a/bottlecaps.scad
+++ b/bottlecaps.scad
@@ -33,7 +33,7 @@ include <rounding.scad>
 // Arguments:
 //   wall = Wall thickness in mm.
 //   ---
-//   anchor = Translate so anchor point is at origin (0,0,0). See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
+//   anchor = Translate so anchor point is at origin (0,0,0). See [anchor](attachments.scad#subsection-anchor).  Default: "support-ring"
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Named Anchors:
@@ -160,22 +160,26 @@ function  pco1810_neck(wall=2, anchor="support-ring", spin=0, orient=UP) =
 //   r = Outer radius of the cap.
 //   d = Outer diameter of the cap.
 //   wall = Wall thickness in mm.
-//   texture = The surface texture of the cap.  Valid values are "none", "knurled", or "ribbed".  Default: "none"
+//   texture = The surface texture of the cap.  Valid values are "none", "knurled", "sharp_knurled", "ribbed", "sharp_ribbed", or "hex_faces". Default: "none"
 //   ---
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `BOTTOM`
 //   spin = Rotate this many degrees around the Z axis after anchor. See [spin](attachments.scad#subsection-spin)  Default: 0
 //   orient = Vector to rotate top toward, after spin. See [orient](attachments.scad#subsection-orient). Default: `UP`
 // Named Anchors:
 //   "inside-top" = Centered on the inside top of the cap.
-// Examples:
+// Example:
 //   pco1810_cap();
-//   pco1810_cap(texture="knurled");
-//   pco1810_cap(texture="ribbed");
-// Example: Standard Anchors
+// Example(Med;VPT=[0,0,8];VPD=200): PCO1810 caps with different texture options. Clockwise from top: knurled, sharp_knurled, ribbed, sharp_ribbed. Center: hex_faces. All textures increase the overall diameter of the part to preserve the original wall thickness.
+//   back(36) pco1810_cap(texture="knurled");
+//   right(36) pco1810_cap(texture="sharp_knurled");
+//   fwd(36) pco1810_cap(texture="ribbed");
+//   left(36) pco1810_cap(texture="sharp_ribbed");
+//   pco1810_cap(texture="hex_faces");
+// Example: Standard anchors
 //   pco1810_cap(texture="ribbed") show_anchors(custom=false);
-// Example: Custom Named Anchors
+// Example: Custom named anchors
 //   expose_anchors(0.3)
-//       pco1810_cap(texture="ribbed")
+//       pco1810_cap(texture="knurled")
 //           show_anchors(std=false);
 module pco1810_cap(h, r, d, wall, texture="none", anchor=BOTTOM, spin=0, orient=UP)
 {
@@ -201,15 +205,7 @@ module pco1810_cap(h, r, d, wall, texture="none", anchor=BOTTOM, spin=0, orient=
     attachable(anchor,spin,orient, d=w, l=hh, anchors=anchors) {
         down(hh/2) zrot(45) {
             difference() {
-                union() {
-                    if (texture == "knurled") {
-                        cyl(d=w, h=hh, texture="diamonds", tex_size=[3,3], style="concave", anchor=BOT);
-                    } else if (texture == "ribbed") {
-                        cyl(d=w, h=hh, texture="ribs", tex_size=[3,3], style="min_edge", anchor=BOT);
-                    } else {
-                        cyl(d=w, l=hh, anchor=BOTTOM);
-                    }
-                }
+                _tex_cyl(w, hh, texture, BOTTOM, "pco1810_cap");
                 up(hh-tamper_ring_h) cyl(d=cap_id, h=tamper_ring_h+wwall, anchor=BOTTOM);
             }
             up(hh-tamper_ring_h+2) thread_helix(d=thread_od-thread_depth*2, pitch=thread_pitch, thread_depth=thread_depth, flank_angle=flank_angle, turns=810/360, lead_in=-thread_depth, internal=true, anchor=BOTTOM);
@@ -254,6 +250,9 @@ function pco1810_cap(h, r, d, wall, texture="none", anchor=BOTTOM, spin=0, orien
 //   expose_anchors(0.3)
 //       pco1881_neck()
 //           show_anchors(std=false);
+
+function pco1881_neck(wall, anchor, spin, orient) = no_function("pco1881_neck");
+
 module pco1881_neck(wall=2, anchor="support-ring", spin=0, orient=UP)
 {
     inner_d = 21.74;
@@ -349,9 +348,6 @@ module pco1881_neck(wall=2, anchor="support-ring", spin=0, orient=UP)
     }
 }
 
-function pco1881_neck(wall=2, anchor="support-ring", spin=0, orient=UP) =
-    no_function("pco1881_neck");
-
 
 // Module: pco1881_cap()
 // Synopsis: Creates a cap for a PCO1881 standard bottle.
@@ -364,44 +360,43 @@ function pco1881_neck(wall=2, anchor="support-ring", spin=0, orient=UP) =
 //   Creates a basic cap for a PCO1881 threaded beverage bottle.
 // Arguments:
 //   wall = Wall thickness in mm.
-//   texture = The surface texture of the cap.  Valid values are "none", "knurled", or "ribbed".  Default: "none"
+//   texture = The surface texture of the cap.  Valid values are "none", "knurled", "sharp_knurled", "ribbed", "sharp_ribbed", or "hex_faces". Default: "none"
 //   ---
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `BOTTOM`
 //   spin = Rotate this many degrees around the Z axis after anchor. See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Named Anchors:
 //   "inside-top" = Centered on the inside top of the cap.
-// Examples:
+// Example:
 //   pco1881_cap();
-//   pco1881_cap(texture="knurled");
-//   pco1881_cap(texture="ribbed");
+// Example(Med;VPT=[0,0,7];VPD=200): PCO1881 caps with different texture options. Clockwise from top: knurled, sharp_knurled, ribbed, sharp_ribbed. Center: hex_faces. All textures increase the overall diameter to preserve the original wall thickness.
+//   back(36) pco1881_cap(texture="knurled");
+//   right(36) pco1881_cap(texture="sharp_knurled");
+//   fwd(36) pco1881_cap(texture="ribbed");
+//   left(36) pco1881_cap(texture="sharp_ribbed");
+//   pco1881_cap(texture="hex_faces");
 // Example: Standard anchors
 //   pco1881_cap(texture="ribbed") show_anchors(custom=false);
 // Example: Custom named anchors
 //   expose_anchors(0.5)
 //       pco1881_cap(texture="ribbed")
 //           show_anchors(std=false);
+
+function pco1881_cap(wall, texture, anchor, spin, orient) = no_function("pco1881_cap");
+
 module pco1881_cap(wall=2, texture="none", anchor=BOTTOM, spin=0, orient=UP)
 {
     $fn = segs(33/2);
     w = 28.58 + 2*wall;
-    h = 11.2 + wall;
+    hh = 11.2 + wall;
     anchors = [
-        named_anchor("inside-top", [0,0,-(h/2-wall)])
+        named_anchor("inside-top", [0,0,-(hh/2-wall)])
     ];
-    attachable(anchor,spin,orient, d=w, l=h, anchors=anchors) {
-        down(h/2) zrot(45) {
+    attachable(anchor,spin,orient, d=w, l=hh, anchors=anchors) {
+        down(hh/2) zrot(45) {
             difference() {
-                union() {
-                    if (texture == "knurled") {
-                        cyl(d=w, h=11.2+wall, texture="diamonds", tex_size=[3,3], style="concave", anchor=BOT);
-                    } else if (texture == "ribbed") {
-                        cyl(d=w, h=11.2+wall, texture="ribs", tex_size=[3,3], style="min_edge", anchor=BOT);
-                    } else {
-                        cyl(d=w, l=11.2+wall, anchor=BOTTOM);
-                    }
-                }
-                up(wall) cyl(d=28.58, h=11.2+wall, anchor=BOTTOM);
+                _tex_cyl(w, hh, texture, BOTTOM, "pco1881_cap");
+                up(wall) cyl(d=28.58, h=hh, anchor=BOTTOM);
             }
             up(wall+2) thread_helix(d=25.5, pitch=2.7, thread_depth=1.6, flank_angle=15, turns=650/360, lead_in=-1.6, internal=true, anchor=BOTTOM);
         }
@@ -409,8 +404,6 @@ module pco1881_cap(wall=2, texture="none", anchor=BOTTOM, spin=0, orient=UP)
     }
 }
 
-function pco1881_cap(wall=2, texture="none", anchor=BOTTOM, spin=0, orient=UP) =
-    no_function("pco1881_cap");
 
 
 
@@ -560,7 +553,7 @@ function generic_bottle_neck(
 //   specify the thread geometry. Most glass bottles conform to the SPI standard and caps for them may be more easily produced using {{sp_cap()}}.
 // Arguments:
 //   wall = Wall thickness.  Default: 2
-//   texture = The surface texture of the cap.  Valid values are "none", "knurled", or "ribbed".  Default: "none"
+//   texture = The surface texture of the cap.  Valid values are "none", "knurled", "sharp_knurled", "ribbed", "sharp_ribbed", or "hex_faces". Default: "none"
 //   ---
 //   height = Interior height of the cap.
 //   thread_od = Outer diameter of the threads.
@@ -601,34 +594,24 @@ module generic_bottle_cap(
     thread_od = !is_undef(thread_od) ? thread_od : neck_od+2*thread_depth;
     threadOuterDTol = thread_od + 2*tolerance;
     w = threadOuterDTol + 2 * wall;
-    h = height + wall;
+    hh = height + wall;
     neckOuterDTol = neck_od + 2 * tolerance;
 
     diamMagMult = (w > 32.58) ? w / 32.58 : 1;
     heightMagMult = (height > 11.2) ? height / 11.2 : 1;
 
     anchors = [
-        named_anchor("inside-top", [0, 0, -(h / 2 - wall)])
+        named_anchor("inside-top", [0, 0, -(hh / 2 - wall)])
     ];
-    attachable(anchor, spin, orient, d = w, l = h, anchors = anchors) {
-        down(h / 2) {
+    attachable(anchor, spin, orient, d = w, l = hh, anchors = anchors) {
+        down(hh / 2) {
             difference() {
-                union() {
-                    // For the knurled and ribbed caps the PCO caps in BOSL2 cut into the wall
-                    // thickness so the wall+texture are the specified wall thickness.  That
-                    // seems wrong so this does specified thickness+texture
-                    if (texture == "knurled") 
-                        cyl(d=w + 1.5*diamMagMult, l=h, texture="diamonds", tex_size=[3,3], style="concave", anchor=BOT);
-                    else if (texture == "ribbed") 
-                        cyl(d=w + 1.5*diamMagMult, l=h, texture="ribs", tex_size=[3,3], style="min_edge", anchor=BOT);
-                    else 
-                        cyl(d = w, l = h, anchor = BOTTOM);
-                }
-                up(wall) cyl(d = threadOuterDTol, h = h, anchor = BOTTOM);
+                _tex_cyl(w, hh, texture, BOTTOM, "generic_bottle_cap");
+                up(wall) cyl(d = threadOuterDTol, h = hh, anchor = BOTTOM);
             }
             up(wall + pitch / 2) {
                 thread_helix(d = neckOuterDTol+.02, pitch = pitch, thread_depth = thread_depth+.01, flank_angle = flank_angle,
-                             turns = ((height - pitch) / pitch), lead_in = -thread_depth, internal = true, anchor = BOTTOM);
+                    turns = ((height - pitch) / pitch), lead_in = -thread_depth, internal = true, anchor = BOTTOM);
             }
         }
         children();
@@ -654,7 +637,7 @@ function generic_bottle_cap(
 //   Creates a threaded neck to cap adapter
 // Arguments:
 //   wall = Thickness of wall between neck and cap when d=0.  Leave undefined to have the outside of the tube go from the OD of the neck support ring to the OD of the cap.  Default: undef
-//   texture = The surface texture of the cap.  Valid values are "none", "knurled", or "ribbed".  Default: "none"
+//   texture = The surface texture of the cap.  Valid values are "none", "knurled", "sharp_knurled", "ribbed", "sharp_ribbed", or "hex_faces". Default: "none"
 //   cap_wall = Wall thickness of the cap in mm. Default: 2
 //   cap_h = Interior height of the cap in mm. Default: 11.2
 //   cap_thread_depth = Cap thread depth.  Default: 1.6
@@ -782,7 +765,7 @@ function bottle_adapter_neck_to_cap(
 //   Creates a threaded cap to cap adapter.
 // Arguments:
 //   wall = Wall thickness in mm.
-//   texture = The surface texture of the cap.  Valid values are "none", "knurled", or "ribbed".  Default: "none"
+//   texture = The surface texture of the cap.  Valid values are "none", "knurled", "sharp_knurled", "ribbed", "sharp_ribbed", or "hex_faces". Default: "none"
 //   cap_h1 = Interior height of top cap. Default: 11.2
 //   cap_thread_depth1 = Thread depth on top cap. Default: 1.6
 //   tolerance = Extra space to add to the outer diameter of threads and neck in mm. Applied to radius. Default: 0.2
@@ -815,7 +798,7 @@ module bottle_adapter_cap_to_cap(
     cap_thread_pitch2,
     d = 0,
     neck_id,
-    taper_lead_in = 0, anchor, spin,orient
+    taper_lead_in = 0, anchor=CENTER, spin,orient
 ) {
     cap_h2 = default(cap_h2,cap_h1);
     cap_thread_depth2 = default(cap_thread_depth2,cap_thread_depth1);
@@ -1056,7 +1039,7 @@ function bottle_adapter_neck_to_neck(
 //   id = inner diameter
 //   style = Either "L" or "M" to specify the thread style.  Default: "L"
 //   bead = if true apply a bead to the neck.  Default: false
-//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
+//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `BOTTOM`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Examples:
@@ -1170,7 +1153,7 @@ function _sp_thread_profile(tpi, a, S, style, flip=false) =
 
 
 function sp_neck(diam,type,wall,id,style="L",bead=false, anchor, spin, orient) = no_function("sp_neck");
-module sp_neck(diam,type,wall,id,style="L",bead=false, anchor, spin, orient)
+module sp_neck(diam,type,wall,id,style="L",bead=false, anchor=BOTTOM, spin, orient)
 {
     assert(num_defined([wall,id])==1, "\nMust define exactly one of wall and id.");
     
@@ -1275,9 +1258,9 @@ module sp_neck(diam,type,wall,id,style="L",bead=false, anchor, spin, orient)
 //   style = Either "L" or "M" to specify the thread style.  Default: "L"
 //   top_adj = Amount to reduce top space in the cap, which means it doesn't screw down as far.  Default: 0
 //   bot_adj = Amount to reduce extension of cap at the bottom, which also means it doesn't screw down as far.  Default: 0
-//   texture = texture for outside of cap, one of "knurled", "ribbed" or "none.  Default: "none"
+//   texture = The surface texture of the cap.  Valid values are "none", "knurled", "sharp_knurled", "ribbed", "sharp_ribbed", or "hex_faces". Default: "none"
 //   $slop = Increase inner diameter by `2 * $slop`.  
-//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
+//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `BOTTOM`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Examples:
@@ -1285,7 +1268,7 @@ module sp_neck(diam,type,wall,id,style="L",bead=false, anchor, spin, orient)
 //   sp_cap(22,400,2);
 //   sp_cap(22,410,2);
 //   sp_cap(28,415,1.5,style="M");
-module sp_cap(diam,type,wall,style="L",top_adj=0, bot_adj=0, texture="none", anchor=CENTER, spin=0, orient=UP)
+module sp_cap(diam,type,wall,style="L",top_adj=0, bot_adj=0, texture="none", anchor=BOTTOM, spin=0, orient=UP)
 {
     table = struct_val(_sp_specs,type);
     dum1=assert(is_def(table),"\nUnknown SP closure type. Must be one of 400, 410, or 415.");
@@ -1309,20 +1292,14 @@ module sp_cap(diam,type,wall,style="L",top_adj=0, bot_adj=0, texture="none", anc
 
     depth = a/2;
     taperlen = 2*a;
-    assert(in_list(texture, ["none","knurled","ribbed"]));
     space=2*depth/10+2*get_slop();
-    attachable(anchor,spin,orient,r= (T+space)/2+wall, l=H-bot_adj+wall){
+    w = T+space+2*wall;
+    hh = H+wall-bot_adj;
+    attachable(anchor,spin,orient,r= (T+space)/2+wall, l=H-bot_adj+wall) {
         xrot(180)
-        up((H-bot_adj)/2-wall/2){
-            difference(){
-                up(wall){
-                   if (texture=="knurled")
-                        cyl(d=T+space+2*wall,l=H+wall-bot_adj,anchor=TOP,texture="trunc_pyramids", tex_size=[3,3], style="convex");
-                   else if (texture == "ribbed") 
-                        cyl(d=T+space+2*wall,l=H+wall-bot_adj,anchor=TOP,chamfer2=.8,tex_taper=0,texture="trunc_ribs", tex_size=[3,3], style="min_edge");
-                   else
-                        cyl(d=T+space+2*wall,l=H+wall-bot_adj,anchor=TOP,chamfer2=.8);
-                }
+        up((H-bot_adj)/2-wall/2) {
+            difference() {
+                up(wall) _tex_cyl(w, hh, texture, TOP, "sp_cap");
                 cyl(d=T+space, l=H-bot_adj+1, anchor=TOP);
             }
             thread_helix(d=T+space-.01, profile=profile, pitch = INCH/tpi, turns=twist/360, lead_in=taperlen, anchor=TOP, internal=true);
@@ -1388,7 +1365,7 @@ function sp_diameter(diam,type) =
 //   id = inner diameter
 //   style = Either "L" or "M" to specify the thread style.  Default: "L"
 //   bead = if true apply a bead to the neck.  Default: false
-//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
+//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `BOTTOM`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Examples:
@@ -1455,7 +1432,7 @@ function _gl_thread_profile(tpi, a, S, style, flip=false) =
 
 
 function mason_neck(diam,type,wall,id,style="L",bead=false, anchor, spin, orient) = no_function("mason_neck");
-module mason_neck(diam,type,wall,id,style="L", bead=false, anchor=CENTER, spin=0, orient=UP)
+module mason_neck(diam,type,wall,id,style="L", bead=false, anchor=BOTTOM, spin=0, orient=UP)
 {
     assert(num_defined([wall,id])==1, "\nMust define exactly one of wall and id.");
     
@@ -1541,9 +1518,9 @@ module mason_neck(diam,type,wall,id,style="L", bead=false, anchor=CENTER, spin=0
 //   style = Either "L" or "M" to specify the thread style.  Default: "L"
 //   top_adj = Amount to reduce top space in the cap, which means it doesn't screw down as far.  Default: 3
 //   bot_adj = Amount to reduce extension of cap at the bottom, which also means it doesn't screw down as far.  Default: 0
-//   texture = texture for outside of cap, one of "knurled", "ribbed" or "none.  Default: "none"
+//   texture = The surface texture of the cap.  Valid values are "none", "knurled", "sharp_knurled", "ribbed", "sharp_ribbed", or "hex_faces". Default: "none"
 //   $slop = Increase inner diameter by `2 * $slop`.  
-//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
+//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `BOTTOM`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Examples:
@@ -1551,7 +1528,7 @@ module mason_neck(diam,type,wall,id,style="L", bead=false, anchor=CENTER, spin=0
 //   mason_cap(86,400,2);
 
 function mason_cap(diam,type,wall,style="L",top_adj=3, bot_adj=0, texture="none", anchor, spin, orient) = no_function("mason_cap");
-module mason_cap(diam,type,wall,style="L",top_adj=3, bot_adj=0, texture="none", anchor=CENTER, spin=0, orient=UP)
+module mason_cap(diam,type,wall,style="L",top_adj=3, bot_adj=0, texture="none", anchor=BOTTOM, spin=0, orient=UP)
 {
     table = struct_val(_gl_specs,type);
     dum1=assert(is_def(table),"\nUnknown glass jar closure type. Must be 400 or 450.");
@@ -1574,20 +1551,14 @@ module mason_cap(diam,type,wall,style="L",top_adj=3, bot_adj=0, texture="none", 
 
     depth = a/2;
     taperlen = 2*a;
-    assert(in_list(texture, ["none","knurled","ribbed"]));
     space=2*depth/10+2*get_slop();
+    w = T+space+2*wall;
+    hh = H+wall-bot_adj;
     attachable(anchor,spin,orient,r= (T+space)/2+wall, l=H-bot_adj+wall){
         xrot(180)
         up((H-bot_adj)/2-wall/2){
-            difference(){
-                up(wall){
-                   if (texture=="knurled")
-                        cyl(d=T+space+2*wall,l=H+wall-bot_adj,anchor=TOP,texture="trunc_pyramids", tex_size=[3,3], style="convex");
-                   else if (texture == "ribbed") 
-                        cyl(d=T+space+2*wall,l=H+wall-bot_adj,anchor=TOP,chamfer2=.8,tex_taper=0,texture="trunc_ribs", tex_size=[3,3], style="min_edge");
-                   else
-                        cyl(d=T+space+2*wall,l=H+wall-bot_adj,anchor=TOP,chamfer2=.8);
-                }
+            difference() {
+                up(wall) _tex_cyl(w, hh, texture, TOP, "mason_cap");
                 cyl(d=T+space, l=H-bot_adj+1, anchor=TOP);
             }
             thread_helix(d=T+space-.01, profile=profile, pitch = INCH/tpi, turns=twist/360, lead_in=taperlen, anchor=TOP, internal=true);

--- a/tests/test_bottlecaps.scadtest
+++ b/tests/test_bottlecaps.scadtest
@@ -154,3 +154,29 @@ module test_sp_diameter() {
 }
 test_sp_diameter();
 '''
+
+[[test]]
+name = "test_mason_neck"
+script = '''
+include <../std.scad>
+include <../bottlecaps.scad>
+
+module test_mason_neck() {
+    $fn = 8;
+    mason_neck(70, 400, 2);
+}
+test_mason_neck();
+'''
+
+[[test]]
+name = "test_mason_cap"
+script = '''
+include <../std.scad>
+include <../bottlecaps.scad>
+
+module test_mason_cap() {
+    $fn = 8;
+    mason_cap(70, 450, 2);
+}
+test_mason_cap();
+'''

--- a/tests/test_threading.scadtest
+++ b/tests/test_threading.scadtest
@@ -77,6 +77,58 @@ test_acme_threaded_nut();
 '''
 
 [[test]]
+name = "test_garden_hose_threaded_rod"
+script = '''
+include <../std.scad>
+include <../threading.scad>
+
+module test_garden_hose_threaded_rod() {
+    $fn = 8;
+    garden_hose_threaded_rod(l=30);
+}
+test_garden_hose_threaded_rod();
+'''
+
+[test]]
+name = "test_garden_hose_male"
+script = '''
+include <../std.scad>
+include <../threading.scad>
+
+module test_garden_hose_male() {
+    $fn = 8;
+    garden_hose_male(wall=3);
+}
+test_garden_hose_male();
+'''
+
+[test]]
+name = "test_garden_hose_female"
+script = '''
+include <../std.scad>
+include <../threading.scad>
+
+module test_garden_hose_female() {
+    $fn = 8;
+    garden_hose_female(wall=4, addl_space=1);
+}
+test_garden_hose_female();
+'''
+
+[test]]
+name = "test_garden_hose_gasket"
+script = '''
+include <../std.scad>
+include <../threading.scad>
+
+module test_garden_hose_gasket() {
+    $fn = 8;
+    garden_hose_gasket();
+}
+test_garden_hose_gasket();
+'''
+
+[[test]]
 name = "test_npt_threaded_rod"
 script = '''
 include <../std.scad>

--- a/tests/test_threading.scadtest
+++ b/tests/test_threading.scadtest
@@ -89,7 +89,7 @@ module test_garden_hose_threaded_rod() {
 test_garden_hose_threaded_rod();
 '''
 
-[test]]
+[[test]]
 name = "test_garden_hose_male"
 script = '''
 include <../std.scad>
@@ -102,7 +102,7 @@ module test_garden_hose_male() {
 test_garden_hose_male();
 '''
 
-[test]]
+[[test]]
 name = "test_garden_hose_female"
 script = '''
 include <../std.scad>
@@ -115,7 +115,7 @@ module test_garden_hose_female() {
 test_garden_hose_female();
 '''
 
-[test]]
+[[test]]
 name = "test_garden_hose_gasket"
 script = '''
 include <../std.scad>

--- a/threading.scad
+++ b/threading.scad
@@ -964,7 +964,7 @@ module acme_threaded_nut(
 // Synopsis: Creates a threaded rod compatible with the North American garden hose thread.
 // SynTags: Geom
 // Topics: Threading, Screws
-// See Also: garden_hose_threaded_nut()
+// See Also: garden_hose_male(), garden_hose_female()
 // Usage:
 //   garden_hose_threaded_rod(d, l|length, [internal=], ...) [ATTACHMENTS];
 // Description:

--- a/threading.scad
+++ b/threading.scad
@@ -63,7 +63,7 @@ _BOSL2_THREADING = is_undef(_BOSL2_STD) && (is_undef(BOSL2_NO_STD_WARNING) || !B
 //   This style of thread is not commonly used in metal fasteners because it requires
 //   machining the threads, which is much more costly than the rolling procedure described
 //   above.  However, plastic threads usually have some sort of gradual thread end.
-//   For models that will be 3D printed, there is no reason to choose the standard
+//   For 3D printed models, there is no reason to choose the standard
 //   bevel end bolt, so in this library the blunt start threads are the default.
 //   If you need standard bevel-end threads, you can choose them with the `blunt_start` options.
 //   Note that blunt start threads are more efficient.
@@ -87,7 +87,7 @@ _BOSL2_THREADING = is_undef(_BOSL2_STD) && (is_undef(BOSL2_NO_STD_WARNING) || !B
 // Figure(3D,Med,NoAxes,VPR=[72,0,54],VPT=[0,0,0],VPD=44): Threaded rod mask produced using `internal=true` with regular bevel at the top and reversed bevel at the bottom.  
 //   threaded_rod(d=13,pitch=2,l=10,blunt_start=true,bevel2=true,bevel1="reverse",internal=true,$fn=80);
 // Continues:
-//   You can also extend the unthreaded section using the `end_len` parameters.  A long unthreaded section will make
+//   You can also extend the unthreaded section using the `end_len` parameters.  A long unthreaded section makes
 //   it impossible to tilt the bolt and produce misaligned threads, so it could make assembly easier.  
 // Figure(3D,Med,NoAxes,VPR=[72,0,54],VPT=[0,0,0],VPD=48): Negative bevel on a regular threaded rod.
 //   threaded_rod(d=13,pitch=2,l=15,end_len2=5,blunt_start=true,bevel=true,$fn=80);
@@ -106,13 +106,13 @@ _BOSL2_THREADING = is_undef(_BOSL2_STD) && (is_undef(BOSL2_NO_STD_WARNING) || !B
 //   is not as good as the others in practice, because the flat faces on the threads can hit each other.
 //   The lead-in shape is produced by applying a scale factor to the thread cross section that varies along the lead-in length. 
 //   You can also specify a custom shape
-//   by giving a function literal, `f(x,L)` where `L` will be the total linear
-//   length of the lead-in section and `x` will be a value between 0 and 1 giving
+//   by giving a function literal, `f(x,L)` where `L` is the total linear
+//   length of the lead-in section and `x` is a value between 0 and 1 giving
 //   the position in the lead in, with 0 being the tip and 1 being the full height thread.
 //   The return value must be a 2-vector giving the thread width scale and thread height
 //   scale at that location.  If `x<0` the function must return a thread height scale
 //   of zero, but it is usually best if the thread width scale does not go to zero,
-//   because that will give a sharply pointed thread end.  If `x>1` the function must
+//   because that results in a sharply-pointed thread end.  If `x>1` the function must
 //   return `[1,1]`.  
 // Figure(3D,Med,NoAxes,VPR=[75,0,338],VPT=[-2,0,3.3],VPD=25): The standard lead in shapes
 //   left_half()zrot(0){
@@ -141,10 +141,10 @@ _BOSL2_THREADING = is_undef(_BOSL2_STD) && (is_undef(BOSL2_NO_STD_WARNING) || !B
 //   threaded_rod(d, l|length, pitch, [internal=], ...) [ATTACHMENTS];
 // Description:
 //   Constructs a standard ISO (metric) or UTS (English) threaded rod.  These threads are close to triangular,
-//   with a 60 degree thread angle.  You can give diameter value which specifies the outer diameter and will produce
-//   the "basic form" or you can
-//   set d to a triplet [d_min, d_pitch, d_major] where are parameters determined by the ISO and UTS specifications
-//   that define clearance sizing for the threading.  See screws.scad for how to make screws
+//   with a 60° thread angle.  You can give diameter value that specifies the outer diameter, producing
+//   the "basic form", or you can
+//   set `d` to a triplet `[d_min, d_pitch, d_major]`, which are parameters determined by the ISO and UTS specifications
+//   that define clearance sizing for the threading.  See [screws.scad](screws.scad) for making screws
 //   using the specification parameters.  
 // Arguments:
 //   d = Outer diameter of threaded rod, or a triplet of [d_min, d_pitch, d_major]. 
@@ -175,7 +175,7 @@ _BOSL2_THREADING = is_undef(_BOSL2_STD) && (is_undef(BOSL2_NO_STD_WARNING) || !B
 //   teardrop = If true, adds a teardrop profile to the back (Y+) side of the threaded rod, for 3d printability of horizontal holes. If numeric, specifies the proportional extra distance of the teardrop flat top from the screw center, or set to "max" for a pointed teardrop. Default: false
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Example(2D):
 //   projection(cut=true)
@@ -313,7 +313,7 @@ module threaded_rod(
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Examples(Med):
 //   threaded_nut(nutwidth=16, id=8, h=8, pitch=1.25, $slop=0.05, $fa=1, $fs=1);
@@ -346,9 +346,9 @@ module threaded_nut(
     anchor, spin, orient
 ) {
     dummy1=
-          assert(all_nonnegative(pitch), "Nut pitch must be nonnegative")
-          assert(all_positive(id), "Nut inner diameter must be positive")
-          assert(all_positive(h),"Nut thickness must be positive");
+          assert(all_nonnegative(pitch), "\nNut pitch must be nonnegative.")
+          assert(all_positive(id), "\nNut inner diameter must be positive.")
+          assert(all_positive(h),"\nNut thickness must be positive.");
     basic = is_num(id) || is_undef(id) || is_def(id1) || is_def(id2);
     dummy2 = assert(basic || is_vector(id,3));
     depth = basic ? cos(30) * 5/8
@@ -396,7 +396,7 @@ module threaded_nut(
 //   For loads in only one direction the asymmetric buttress thread profile can bear greater loads.  
 //   .
 //   By default produces the nominal dimensions
-//   for metric trapezoidal threads: a thread angle of 30 degrees and a depth set to half the pitch.
+//   for metric trapezoidal threads: a thread angle of 30° and a depth set to half the pitch.
 //   You can also specify your own trapezoid parameters.  For ACME threads see acme_threaded_rod().
 // Figure(2D,Med,NoAxes):
 //   pa_delta = tan(15)/4;
@@ -478,31 +478,64 @@ module threaded_nut(
 //   teardrop = If true, adds a teardrop profile to the back (Y+) side of the threaded rod, for 3d printability of horizontal holes. If numeric, specifies the proportional extra distance of the teardrop flat top from the screw center, or set to "max" for a pointed teardrop. Default: false
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
-// Example(2D):
+// Example(2D): A threaded rod profile.
 //   projection(cut=true)
-//       trapezoidal_threaded_rod(d=10, l=15, pitch=2, orient=BACK);
-// Examples(Med): 
-//   trapezoidal_threaded_rod(d=10, l=40, pitch=2, $fn=32);  // Standard metric threading
-//   rot(-65)trapezoidal_threaded_rod(d=10, l=17, pitch=2, blunt_start=false, $fn=32);  // Standard metric threading
-//   trapezoidal_threaded_rod(d=10, l=17, pitch=2, bevel=true, $fn=32);  // Standard metric threading
-//   trapezoidal_threaded_rod(d=10, h=30, pitch=2, left_handed=true, $fa=1, $fs=1);  // Standard metric threading
-//   trapezoidal_threaded_rod(d=10, l=40, pitch=3, left_handed=true, starts=3, $fn=36);
-//   trapezoidal_threaded_rod(l=25, d=10, pitch=2, starts=3, $fa=1, $fs=1, bevel=true, orient=RIGHT, anchor=BOTTOM);
-//   trapezoidal_threaded_rod(d=60, l=16, pitch=8, thread_depth=3, thread_angle=90, blunt_start=false, $fa=2, $fs=2);
-//   trapezoidal_threaded_rod(d=60, l=16, pitch=8, thread_depth=3, thread_angle=90, end_len=0, $fa=2, $fs=2);   
-//   trapezoidal_threaded_rod(d=60, l=16, pitch=8, thread_depth=3, thread_angle=90, left_handed=true, starts=4, $fa=2, $fs=2,end_len=0);
-//   trapezoidal_threaded_rod(d=16, l=40, pitch=2, thread_angle=60);
-//   trapezoidal_threaded_rod(d=25, l=40, pitch=10, thread_depth=8/3, thread_angle=100, starts=4, anchor=BOT, $fa=2, $fs=2,end_len=-2);
-//   trapezoidal_threaded_rod(d=50, l=35, pitch=8, thread_angle=60, starts=11, lead_in=3, $fn=120);
-//   trapezoidal_threaded_rod(d=10, l=40, end_len2=10, pitch=2, $fn=32);  // Unthreaded top end section
-// Example(Med): Using as a Mask to Make Internal Threads
+//       trapezoidal_threaded_rod(d=10, l=15, pitch=2,
+//          orient=BACK);
+// Example: Standard metric threading
+//   trapezoidal_threaded_rod(d=10, l=40, pitch=2, $fn=32);
+// Example: Standard metric threading with `blunt_start` disabled, causing `bevel=true` to be the default.
+//   rot(-65) trapezoidal_threaded_rod(d=10, l=17, pitch=2,
+//       blunt_start=false, $fn=32);
+// Example: Standard metric threading with default `blunt_start=true` and forced `bevel=true`.
+//   trapezoidal_threaded_rod(d=10, l=17, pitch=2,
+//       bevel=true, $fn=32);
+// Example: Standard metric left-hand threadh 
+//   trapezoidal_threaded_rod(d=10, h=30, pitch=2,
+//       left_handed=true, $fa=1, $fs=1);
+// Example: Triple left-hand thread.
+//   trapezoidal_threaded_rod(d=10, l=40, pitch=3,
+//       left_handed=true, starts=3, $fn=36);
+// Example: Triple thread with anchoring and orientation demonstrated.
+//   trapezoidal_threaded_rod(l=25, d=10, pitch=2,
+//       starts=3, $fa=1, $fs=1, bevel=true,
+//       orient=RIGHT, anchor=BOTTOM);
+// Example: A 90° thread, resulting in 45° slopes friendly for 3D printing.
+//   trapezoidal_threaded_rod(d=60, l=16, pitch=8,
+//       thread_depth=3, thread_angle=90,
+//       blunt_start=false, $fa=2, $fs=2);
+// Example: A 90° thread occupying the full length of the rod.
+//   trapezoidal_threaded_rod(d=60, l=16, pitch=8,
+//       thread_depth=3, thread_angle=90,
+//       end_len=0, $fa=2, $fs=2);
+// Example: Quadruple left-handed 90° threads on a short cylinder, approximating fastening lugs.
+//   trapezoidal_threaded_rod(d=60, l=16, pitch=8,
+//       thread_depth=3, thread_angle=90,
+//       left_handed=true, starts=4,
+//       $fa=2, $fs=2,end_len=0);
+// Example(Med):
+//   trapezoidal_threaded_rod(d=16, l=40,
+//       pitch=2, thread_angle=60);
+// Example:
+//   trapezoidal_threaded_rod(d=25, l=40,
+//       pitch=10, thread_depth=8/3,
+//       thread_angle=100, starts=4, anchor=BOT,
+//       $fa=2, $fs=2,end_len=-2);
+// Example:
+//   trapezoidal_threaded_rod(d=50, l=35,
+//       pitch=8, thread_angle=60,
+//       starts=11, lead_in=3, $fn=120);
+// Example: Unthreaded top end section
+//   trapezoidal_threaded_rod(d=10, l=40,
+//       end_len2=10, pitch=2, $fn=32);
+// Example(Med): Using as a mask to make internal threads
 //   bottom_half() difference() {
 //       cube(50, center=true);
 //       trapezoidal_threaded_rod(d=40, l=51, pitch=5, thread_angle=30, internal=true, bevel=true, orient=RIGHT, $fn=36);
 //   }
-// Example(Med;VPR=[100,0,5];VPD=220): Masking a Horizontal Threaded Hole
+// Example(Med;VPR=[100,0,5];VPD=220): Masking a horizontal threaded hole
 //   difference() {
 //     cuboid(50);
 //     trapezoidal_threaded_rod(
@@ -513,6 +546,52 @@ module threaded_nut(
 //         teardrop=true, orient=FWD
 //     );
 //   }
+// Example(Med): Garden hose threads on male and female connectors (cross section view) using specifications from ASME B1.20.7-1991
+//   tpi = 11.5;  // threads per inch
+//   pitch = 1/tpi * INCH;
+//   thread_depth = 0.649519*pitch;
+//   $fn=64;
+//   
+//   // make nipple (male end)
+//   
+//   dia_male = (1 + 1/16) * INCH; // 1.0625"
+//   pilot = 1/8 * INCH;
+//   nipple_len = 9/16 * INCH;
+//   nipple_inside_dia = 25/32 * INCH;
+//   
+//   color("gold") down(pitch) difference() {
+//       zrot(195) trapezoidal_threaded_rod(d=dia_male,
+//           l=nipple_len, pitch=pitch,
+//           thread_depth=thread_depth, thread_angle=60,
+//           end_len2=pilot, bevel2=0.2, lead_in_ang2=44,
+//           anchor=BOTTOM);
+//       down(0.1) cylinder(nipple_len+0.2, d=nipple_inside_dia);
+//       translate([0.1,-20.1,-1]) cube(25); // cut section
+//   }
+//   
+//   // make coupling (female end)
+//   
+//   dia_female = (1 + 1/16 + 0.01) * INCH; // 1.0725"
+//   coupling_len = 17/32 * INCH;
+//   coupling_thread_len = 3/8 * INCH;
+//   gasket_space = coupling_len - coupling_thread_len;
+//   wall = 5;  // arbitrary, make bigger, add knurl, etc.
+//   gasket_seat_thickness = 6; // arbitrary
+//   coupling_total_len = coupling_len + gasket_seat_thickness;
+//   
+//   color("silver") difference() {
+//       cylinder(coupling_len+gasket_seat_thickness,
+//           d=dia_female+2*wall);
+//       down(0.2) cylinder(coupling_total_len+0.4,
+//           d=nipple_inside_dia+1);
+//       down(0.1) trapezoidal_threaded_rod(d=dia_female,
+//           l=coupling_len+0.1, pitch=pitch,
+//           thread_depth=thread_depth, thread_angle=60,
+//           internal=true, end_len1=0.1, end_len2=gasket_space,
+//           lead_in_ang1=38, anchor=BOTTOM);
+//       translate([0,-20,-1]) cube(25); // cut section
+//   }
+
 function trapezoidal_threaded_rod(
     d, l, pitch,
     thread_angle,
@@ -549,15 +628,15 @@ module trapezoidal_threaded_rod(
     teardrop=false,
     anchor, spin, orient
 ) {
-    dummy0 = assert(num_defined([thread_angle,flank_angle])<=1, "Cannot define both flank angle and thread angle");
+    dummy0 = assert(num_defined([thread_angle,flank_angle])<=1, "\nCannot define both flank angle and thread angle.");
     thread_angle = first_defined([thread_angle, u_mul(2,flank_angle), 30]);
-    dummy1 = assert(all_nonnegative(pitch),"Must give a positive pitch value")
-             assert(thread_angle>=0 && thread_angle<180, "Invalid thread angle or flank angle")
+    dummy1 = assert(all_nonnegative(pitch),"\nMust give a positive pitch value.")
+             assert(thread_angle>=0 && thread_angle<180, "\nInvalid thread angle or flank angle.")
              assert(thread_angle<=90 || all_positive([thread_depth]),
-                   "Thread angle (2*flank_angle) must be smaller than 90 degrees with default thread depth of pitch/2");
+                   "\nThread angle (2*flank_angle) must be smaller than 90° with default thread depth of pitch/2.");
     depth = first_defined([thread_depth,pitch/2]);
     pa_delta = 0.5*depth*tan(thread_angle/2) / pitch;
-    dummy2 = assert(pa_delta<=1/4, "Specified thread geometry is impossible");
+    dummy2 = assert(pa_delta<=1/4, "\nSpecified thread geometry is impossible.");
     rr1 = -depth/pitch;
     z1 = 1/4-pa_delta;
     z2 = 1/4+pa_delta;
@@ -588,7 +667,7 @@ module trapezoidal_threaded_rod(
 //   trapezoidal_threaded_nut(nutwidth, id, h|height|thickness, pitch, [thread_angle=|flank_angle=], [thread_depth], ...) [ATTACHMENTS];
 // Description:
 //   Constructs a hex nut or square nut for a symmetric trapzoidal threaded rod.  By default produces
-//   the nominal dimensions for metric trapezoidal threads: a thread angle of 30 degrees and a depth
+//   the nominal dimensions for metric trapezoidal threads: a thread angle of 30° and a depth
 //   set to half the pitch.  You can also specify your own trapezoid parameters.  For ACME threads see
 //   acme_threaded_nut().
 // Arguments:
@@ -625,7 +704,7 @@ module trapezoidal_threaded_rod(
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Examples(Med):
 //   trapezoidal_threaded_nut(nutwidth=16, id=8, h=8, pitch=2, $slop=0.1, anchor=UP);
@@ -678,15 +757,15 @@ module trapezoidal_threaded_nut(
     lead_in_shape="default",
     anchor, spin, orient
 ) {
-    dummy0 = assert(num_defined([thread_angle,flank_angle])<=1, "Cannot define both flank angle and thread angle");
+    dummy0 = assert(num_defined([thread_angle,flank_angle])<=1, "\nCannot define both flank angle and thread angle.");
     thread_angle = first_defined([thread_angle, u_mul(2,flank_angle), 30]);
-    dummy1 = assert(all_nonnegative(pitch),"Must give a positive pitch value")
-             assert(thread_angle>=0 && thread_angle<180, "Invalid thread angle or flank angle")
+    dummy1 = assert(all_nonnegative(pitch),"\nMust give a positive pitch value.")
+             assert(thread_angle>=0 && thread_angle<180, "\nInvalid thread angle or flank angle.")
              assert(thread_angle<=90 || all_positive([thread_depth]),
-                   "Thread angle (2*flank_angle) must be smaller than 90 degrees with default thread depth of pitch/2");
+                   "\nThread angle (2*flank_angle) must be smaller than 90° with default thread depth of pitch/2.");
     depth = first_defined([thread_depth,pitch/2]);
     pa_delta = 0.5*depth*tan(thread_angle/2) / pitch;
-    dummy2 = assert(pitch==0 || pa_delta<1/4, "Specified thread geometry is impossible");
+    dummy2 = assert(pitch==0 || pa_delta<1/4, "\nSpecified thread geometry is impossible.");
     rr1 = -depth/pitch;
     z1 = 1/4-pa_delta;
     z2 = 1/4+pa_delta;
@@ -717,7 +796,7 @@ module trapezoidal_threaded_nut(
 // Usage:
 //   acme_threaded_rod(d, l|length, tpi|pitch=, [internal=], ...) [ATTACHMENTS];
 // Description:
-//   Constructs an ACME trapezoidal threaded screw rod.  This form has a 29 degree thread angle with a
+//   Constructs an ACME trapezoidal threaded screw rod.  This form has a 29° thread angle with a
 //   symmetric trapezoidal thread.  
 // Arguments:
 //   d = Outer diameter of threaded rod.
@@ -747,7 +826,7 @@ module trapezoidal_threaded_nut(
 //   teardrop = If true, adds a teardrop profile to the back (Y+) side of the threaded rod, for 3d printability of horizontal holes. If numeric, specifies the proportional extra distance of the teardrop flat top from the screw center, or set to "max" for a pointed teardrop. Default: false
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Example(2D):
 //   projection(cut=true)
@@ -795,7 +874,7 @@ module acme_threaded_rod(
     teardrop=false,
     anchor, spin, orient
 ) {
-    dummy = assert(num_defined([pitch,tpi])==1,"Must give exactly one of pitch and tpi");
+    dummy = assert(num_defined([pitch,tpi])==1,"\nMust give exactly one of pitch and tpi.");
     pitch = is_undef(pitch) ? INCH/tpi : pitch;
     trapezoidal_threaded_rod(
         d=d, l=l, pitch=pitch,
@@ -859,7 +938,7 @@ module acme_threaded_rod(
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Examples(Med):
 //   acme_threaded_nut(nutwidth=16, id=3/8*INCH, h=8, tpi=8, $slop=0.05);
@@ -895,7 +974,7 @@ module acme_threaded_nut(
     lead_in_shape="default",
     anchor, spin, orient
 ) {
-    dummy = assert(num_defined([pitch,tpi])==1,"Must give exactly one of pitch and tpi");
+    dummy = assert(num_defined([pitch,tpi])==1,"\nMust give exactly one of pitch and tpi.");
     pitch = is_undef(pitch) ? INCH/tpi : pitch;
     dummy2=assert(is_num(pitch) && pitch>=0);
     trapezoidal_threaded_nut(
@@ -932,8 +1011,8 @@ module acme_threaded_nut(
 //   npt_threaded_rod(size, [internal=], ...) [ATTACHMENTS];
 // Description:
 //   Constructs a standard NPT pipe end threading. If `internal=true`, creates a mask for making
-//   internal pipe threads.  Tapers smaller upwards if `internal=false`.  Tapers smaller downwards
-//   if `internal=true`.  If `hollow=true` and `internal=false`, then the pipe threads will be
+//   internal pipe threads.  Tapers smaller upward if `internal=false`.  Tapers smaller downward
+//   if `internal=true`.  If `hollow=true` and `internal=false`, then the pipe threads are
 //   hollowed out into a pipe with the apropriate internal diameter.
 // Arguments:
 //   size = NPT standard pipe size in inches.  1/16", 1/8", 1/4", 3/8", 1/2", 3/4", 1", 1+1/4", 1+1/2", or 2".  Default: 1/2"
@@ -946,7 +1025,7 @@ module acme_threaded_nut(
 //   internal = If true, make this a mask for making internal threads.
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Example(2D): The straight gray rectangle reveals the tapered threads.  
 //   projection(cut=true) npt_threaded_rod(size=1/4, orient=BACK);
@@ -986,7 +1065,7 @@ module npt_threaded_rod(
     assert(is_undef(bevel) || is_bool(bevel));
     assert(is_bool(hollow));
     assert(is_bool(internal));
-    assert(!(internal&&hollow), "Cannot created a hollow internal threads mask.");
+    assert(!(internal&&hollow), "\nCannot created a hollow internal threads mask.");
     info_table = [
         // Size    len      OD    TPI
         [ 1/16,  [ 0.3896, 0.308, 27  ]],
@@ -1001,7 +1080,7 @@ module npt_threaded_rod(
         [ 2,     [ 1.0582, 2.362, 11.5]],
     ];
     info = [for (data=info_table) if(approx(size,data[0])) data[1]][0];
-    dummy1 = assert(is_def(info), "Unsupported NPT size.  Try one of 1/16, 1/8, 1/4, 3/8, 1/2, 3/4, 1, 1+1/4, 1+1/2, 2");
+    dummy1 = assert(is_def(info), "\nUnsupported NPT size. Try one of 1/16, 1/8, 1/4, 3/8, 1/2, 3/4, 1, 1+1/4, 1+1/2, 2.");
     l = INCH * info[0];
     d = INCH * info[1];
     pitch = INCH / info[2];
@@ -1084,7 +1163,7 @@ module npt_threaded_rod(
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Examples(Med):
 //   bspp_threaded_rod(size=3/8, length = 10, $fn=72);
@@ -1150,12 +1229,12 @@ module bspp_threaded_rod(
     anchor, spin, orient
 )
 {
-    assert(!is_undef(size), "undefined size");
-    assert(is_num(size), "size is not a number");
+    assert(!is_undef(size), "\nUndefined size.");
+    assert(is_num(size), "\nsize is not a number.");
     _pitch = 0;
     _diameter = 1;
     index = search(size, bspp_dimensions);
-    forcefuncall = assert(len(index), str("Unsupported BSPP size ", size, "."));
+    forcefuncall = assert(len(index), str("\nUnsupported BSPP size ", size, "."));
     p = INCH / bspp_dimensions[index[0]][1][_pitch];
     d = INCH * bspp_dimensions[index[0]][1][_diameter];
     theta = 55 / 2;
@@ -1208,7 +1287,7 @@ module bspp_threaded_rod(
 // Usage:
 //   buttress_threaded_rod(d, l|length, pitch, [internal=], ...) [ATTACHMENTS];
 // Description:
-//   Constructs a simple buttress threaded rod with a 45 degree angle.  The buttress thread or sawtooth thread has low friction and high loading
+//   Constructs a simple buttress threaded rod with a 45° angle.  The buttress thread or sawtooth thread has low friction and high loading
 //   in one direction at the cost of higher friction and inferior loading in the other direction.  Buttress threads are sometimes used on
 //   vises, which are loaded only in one direction.  
 // Arguments:
@@ -1240,7 +1319,7 @@ module bspp_threaded_rod(
 //   d2 = Top outside diameter of threads.
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Example(2D):
 //   projection(cut=true)
@@ -1354,7 +1433,7 @@ module buttress_threaded_rod(
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Examples(Med):
 //   buttress_threaded_nut(nutwidth=16, id=8, h=8, pitch=1.25, left_handed=true, $slop=0.05, $fa=1, $fs=1);
@@ -1454,7 +1533,7 @@ module buttress_threaded_nut(
 //   d2 = Top outside diameter of threads.
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Example(2D):
 //   projection(cut=true)
@@ -1562,7 +1641,7 @@ module square_threaded_rod(
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Examples(Med):
 //   square_threaded_nut(nutwidth=16, id=10, h=10, pitch=2, starts=2, $slop=0.1, $fn=32);
@@ -1634,7 +1713,7 @@ module square_threaded_nut(
 //   l / length / h / height = Length of threaded rod.
 //   pitch = Thread spacing. Also, the diameter of the ball bearings used.
 //   ball_diam = The diameter of the ball bearings to use with this ball screw.
-//   ball_arc = The arc portion that should touch the ball bearings. Default: 120 degrees.
+//   ball_arc = The arc portion, in degrees, that should touch the ball bearings. Default: 120
 //   ---
 //   left_handed = if true, create left-handed threads.  Default = false
 //   starts = The number of lead starts.  Default = 1
@@ -1657,7 +1736,7 @@ module square_threaded_nut(
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Example(2D): Thread Profile, ball_diam=4, ball_arc=100
 //   projection(cut=true) ball_screw_rod(d=10, l=15, pitch=5, ball_diam=4, ball_arc=100, orient=BACK, $fn=24, blunt_start=false);
@@ -1737,8 +1816,8 @@ module ball_screw_rod(
 //   Constructs a generic threaded rod using an arbitrary thread profile that you supply.  The rod can be tapered
 //   (e.g. for pipe threads).  For specific thread types use other modules that supply the appropriate profile.
 //   .
-//   You give the profile as a 2D path that will be scaled by the pitch to produce the final thread shape.  The profile
-//   X values must be between -1/2 and 1/2.  The Y=0 point will align with the specified rod diameter, so generally you
+//   You give the profile as a 2D path that gets scaled by the pitch to produce the final thread shape.  The profile
+//   X values must be between -1/2 and 1/2.  The Y=0 point aligns with the specified rod diameter, so generally you
 //   want a Y value of zero at the peak (which makes your specified diameter the outer diameter of the threads).  The
 //   value in the valleys of the thread should then be `-depth/pitch` due to the scaling by the thread pitch.  The first
 //   and last points should generally have the same Y value, but it is not necessary to give values at X=1/2 or X=-1/2
@@ -1747,10 +1826,10 @@ module ball_screw_rod(
 //   .
 //   If internal is true then produce a thread mask to difference from an object.  When internal is true the rod
 //   diameter is enlarged to correct for the polygonal nature of circles to ensure that the internal diameter is the
-//   specified size.  The diameter is also increased by `4 * $slop` to create clearance for threading by allowing a `2 *
-//   $slop` gap on each side.  If bevel is set to true and internal is false then the ends of the rod will be beveled.
-//   When bevel is true and internal is true the ends of the rod will be filled in so that the rod mask will create a
-//   bevel when subtracted from an object.  The bevel is at 45 deg and is the depth of the threads.
+//   specified size.  The diameter is also increased by `4 * $slop` to create clearance for threading by allowing a
+//   `2 * $slop` gap on each side. If `bevel=true` and `internal=false` then the ends of the rod are beveled.
+//   When `bevel=true` and `internal=true`, the ends of the rod are filled in so that the rod mask creates a
+//   bevel when subtracted from an object.  The bevel is at 45° and is the depth of the threads.
 //   .
 //   Blunt start threading, which is the default, specifies that the thread ends abruptly at its full width instead of
 //   running off the end of the shaft and leaving a sharp edged partial thread at the end of the screw.  This makes
@@ -1758,7 +1837,7 @@ module ball_screw_rod(
 //   faster to model, but if you really need standard threads that run off the end you can set `blunt_start=false`.
 //   .
 //   The teardrop option cuts off the threads with a teardrop for 3d printability of horizontal holes.  By default,
-//   if the screw outer radius is r then the flat top will be at distance 1.05r from the center, adding a 5% space.  
+//   if the screw outer radius is r then the flat top is distance 1.05r from the center, adding a 5% space.  
 //   You can set teardrop to a numerical value to adjust that percentage, e.g. a value of 0.1 would give a 10% space.
 //   You can set teardrop to "max" to create a pointy-top teardrop with no flat section.  
 // Arguments:
@@ -1791,9 +1870,9 @@ module ball_screw_rod(
 //   teardrop = If true, adds a teardrop profile to the back (Y+) side of the threaded rod, for 3d printability of horizontal holes. If numeric, specifies the proportional extra distance of the teardrop flat top from the screw center, or set to "max" for a pointed teardrop (see above). Default: false
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
-// Example(2DMed,VPD=1.92,VPT=[0.00,-0.30,2.5]): Example Tooth Profile.  Note that the X range of the profile must be in [-1/2,1/2] because the profile will be scaled up by the pitch in order to produce the final thread profile.  
+// Example(2DMed,VPD=1.92,VPT=[0.00,-0.30,2.5]): Example Tooth Profile.  Note that the X range of the profile must be in [-1/2,1/2] because the profile is scaled up by the pitch to produce the final thread profile.  
 //   pitch = 2;
 //   depth = pitch * cos(30) * 5/8;
 //   profile = [
@@ -1856,20 +1935,20 @@ module generic_threaded_rod(
     lead_in1 = first_defined([lead_in1, lead_in]);
     lead_in2 = first_defined([lead_in2, lead_in]);
     lead_in_func = is_func(lead_in_shape) ? lead_in_shape
-                 : assert(is_string(lead_in_shape),"lead_in_shape must be a function or string")
+                 : assert(is_string(lead_in_shape),"\nlead_in_shape must be a function or string.")
                    let(ind = search([lead_in_shape], _lead_in_table,0)[0])
-                   assert(ind!=[],str("Unknown lead_in_shape, \"",lead_in_shape,"\""))
+                   assert(ind!=[],str("\nUnknown lead_in_shape, \"",lead_in_shape,"\"."))
                    _lead_in_table[ind[0]][1];
     dummy0 = 
-      assert(all_positive([pitch]),"Thread pitch must be a positive value")
-      assert(all_positive([len]),"Length must be a postive value")
-      assert(is_path(profile),"Profile must be a path")
-      assert(is_bool(blunt_start1), "blunt_start1/blunt_start must be boolean")
-      assert(is_bool(blunt_start2), "blunt_start2/blunt_start must be boolean")
+      assert(all_positive([pitch]),"\nThread pitch must be a positive value.")
+      assert(all_positive([len]),"\nLength must be a postive value.")
+      assert(is_path(profile),"\nProfile must be a path.")
+      assert(is_bool(blunt_start1), "\nblunt_start1/blunt_start must be boolean.")
+      assert(is_bool(blunt_start2), "\nblunt_start2/blunt_start must be boolean.")
       assert(is_bool(left_handed))
-      assert(all_positive([r1,r2]), "Must give d or both d1 and d2 as positive values")
-      assert(is_undef(bevel1) || is_num(bevel1) || is_bool(bevel1) || bevel1=="reverse", "bevel1/bevel must be a number, boolean or \"reverse\"")
-      assert(is_undef(bevel2) || is_num(bevel2) || is_bool(bevel2) || bevel2=="reverse", "bevel2/bevel must be a number, boolean or \"reverse\"");
+      assert(all_positive([r1,r2]), "\nMust give d or both d1 and d2 as positive values.")
+      assert(is_undef(bevel1) || is_num(bevel1) || is_bool(bevel1) || bevel1=="reverse", "\nbevel1/bevel must be a number, boolean or \"reverse\".")
+      assert(is_undef(bevel2) || is_num(bevel2) || is_bool(bevel2) || bevel2=="reverse", "\nbevel2/bevel must be a number, boolean or \"reverse\".");
 
     sides = quantup(segs(max(r1,r2)), starts);
     rsc = internal? (1/cos(180/sides)) : 1;    // Internal radius adjusted for faceting
@@ -1878,8 +1957,8 @@ module generic_threaded_rod(
     r2adj = r2 * rsc + islop;
     profbounds = pointlist_bounds(profile);
     dummy4 = assert(profbounds[0].x>=-1/2 && profbounds[1].x<=1/2,
-                    "profile's x values must lie in the interval [-1/2,1/2]")
-             assert(profile[0].x<last(profile).x, "profile's first point must have smaller x value than its last point");
+                    "\nprofile's x values must lie in the interval [-1/2,1/2].")
+             assert(profile[0].x<last(profile).x, "\nprofile's first point must have smaller x value than its last point.");
     extreme = internal? profbounds[1].y : profbounds[0].y;
     profile = !internal ? profile
             : let(
@@ -1914,7 +1993,7 @@ module generic_threaded_rod(
     // applied later via difference/union if blunt start is off, so set bevel to zero in the latter case.  
     bevel_size1 = blunt_start1?bev1:0;
     bevel_size2 = blunt_start2?bev2:0;
-    // This is the bevel size for clipping, which is only done when blunt start is off
+    // This is the bevel size for clipping, which is done only when blunt start is off
     clip_bev1 = blunt_start1?0:bev1;
     clip_bev2 = blunt_start2?0:bev2;
     end_len1_base = !blunt_start1? 0 : first_defined([end_len1,end_len, 0]);
@@ -1932,9 +2011,9 @@ module generic_threaded_rod(
     turns2 = len2/pitch+1;
     dir = left_handed? -1 : 1;
     dummy2=
-        assert(abs(bevel_size1)+abs(bevel_size2)<len, "Combined bevel size exceeds length of screw")
-        assert(r1adj+extreme*pitch-bevel_size1>0, "bevel1 is too large to fit screw diameter")
-        assert(r2adj+extreme*pitch-bevel_size2>0, "bevel2 is too large to fit screw diameter");
+        assert(abs(bevel_size1)+abs(bevel_size2)<len, "\nCombined bevel size exceeds length of screw.")
+        assert(r1adj+extreme*pitch-bevel_size1>0, "\nbevel1 is too large to fit screw diameter.")
+        assert(r2adj+extreme*pitch-bevel_size2>0, "\nbevel2 is too large to fit screw diameter.");
          
     margin1 = profile[0].y==extreme ? profile[0].x : -1/2;
     margin2 = last(profile).y==extreme? last(profile).x : 1/2;
@@ -1945,7 +2024,7 @@ module generic_threaded_rod(
          let(
              user_ang = first_defined([lead_in_ang1,lead_in_ang])
          )
-         assert(is_undef(user_ang) || is_undef(lead_in1), "Cannot define lead_in/lead_in1 by both length and angle")
+         assert(is_undef(user_ang) || is_undef(lead_in1), "\nCannot define lead_in/lead_in1 by both length and angle.")
          quantup(
                  is_def(user_ang) ? user_ang : default(lead_in1, lead_in_default)*360/(2*PI*r1adj)
                  , 360/sides);
@@ -1953,7 +2032,7 @@ module generic_threaded_rod(
          let(
              user_ang = first_defined([lead_in_ang2,lead_in_ang])
          )
-         assert(is_undef(user_ang) || is_undef(lead_in2), "Cannot define lead_in/lead_in2 by both length and angle")
+         assert(is_undef(user_ang) || is_undef(lead_in2), "\nCannot define lead_in/lead_in2 by both length and angle.")
          quantup(
                  is_def(user_ang) ? user_ang : default(lead_in2, lead_in_default)*360/(2*PI*r2adj)
                  , 360/sides);
@@ -1964,9 +2043,9 @@ module generic_threaded_rod(
     cut_ang1 = quantup(360 * (len1/pitch-margin1+end_len1/pitch) / starts + lead_in_ang1-360*turns1/starts,360/sides)+360*turns1/starts;
     cut_ang2 = quantdn(360 * (len2/pitch-margin2-end_len2/pitch) / starts - lead_in_ang2-360*turns1/starts,360/sides)+360*turns1/starts;
     dummy1 =
-      assert(cut_ang1<cut_ang2, "lead in length are too long for the amount of thread: they overlap")
-      assert(is_num(lead_in_ang1), "lead_in1/lead_in must be a number")
-      assert(r1adj+profmin>0 && r2adj+profmin>0, "Screw profile deeper than rod radius");
+      assert(cut_ang1<cut_ang2, "\nlead in lengths are too long for the amount of thread: they overlap.")
+      assert(is_num(lead_in_ang1), "\nlead_in1/lead_in must be a number.")
+      assert(r1adj+profmin>0 && r2adj+profmin>0, "\nScrew profile deeper than rod radius.");
     map_threads = right((r1adj + r2adj) / 2)                   // Shift profile out to thread radius
                 * affine3d_skew(sxz=(r2adj-r1adj)/len)         // Skew correction for tapered threads
                 * frame_map(x=[0,0,1], y=[1,0,0])          // Map profile to 3d, parallel to z axis
@@ -1990,7 +2069,7 @@ module generic_threaded_rod(
                     for (turns = [turns1:1:turns2]) 
                         let(
                             tang = turns/starts * 360 + ang,
-                            // _EPSILON offset prevents funny looking extensions of the thread from its very tip
+                            // _EPSILON offset prevents funny looking extensions of the thread from its tip
                             // by forcing values near the tip to evaluate as less than zero = beyond the tip end
                             hsc = tang < cut_ang1 ? lead_in_func(-_EPSILON+1-(cut_ang1-tang)/lead_in_ang1,PI*2*r1adj*lead_in_ang1/360 )
                                 : tang > cut_ang2 ? lead_in_func(-_EPSILON+1-(tang-cut_ang2)/lead_in_ang2,PI*2*r2adj*lead_in_ang2/360 )
@@ -2026,9 +2105,9 @@ module generic_threaded_rod(
                           ]);
     slope = (r1adj-r2adj)/len;
     dummy3 = 
-      assert(r1adj+pmax-clip_bev1>0, "bevel1 is too large to fit screw diameter")
-      assert(r2adj+pmax-clip_bev2>0, "bevel2 is too large to fit screw diameter")
-      assert(abs(clip_bev1)+abs(clip_bev2)<len, "Combined bevel size exceeds length of screw");
+      assert(r1adj+pmax-clip_bev1>0, "\nbevel1 is too large to fit screw diameter.")
+      assert(r2adj+pmax-clip_bev2>0, "\nbevel2 is too large to fit screw diameter.")
+      assert(abs(clip_bev1)+abs(clip_bev2)<len, "\nCombined bevel size exceeds length of screw.");
     
     attachable(anchor,spin,orient, r1=r1adj, r2=r2adj, l=len) {
         union(){
@@ -2066,11 +2145,11 @@ module generic_threaded_rod(
 
           // Add teardrop profile
           if (teardrop!=false) {
-              fact = is_num(teardrop) ? assert(teardrop>=0,"teardrop value cannot be negative")1-1/sqrt(2)+teardrop
+              fact = is_num(teardrop) ? assert(teardrop>=0,"\nteardrop value cannot be negative.")1-1/sqrt(2)+teardrop
                    : is_bool(teardrop) ? 1-1/sqrt(2)+0.05
                    : teardrop=="max" ? 1/sqrt(2)
-                   : assert(false,"invalid teardrop value");
-              dummy = assert(fact<=1/sqrt(2), "teardrop value too large");
+                   : assert(false,"\ninvalid teardrop value.");
+              dummy = assert(fact<=1/sqrt(2), "\nteardrop value too large.");
               pdepth = pmax-profmin;              
               trap1 = back((r1adj+pmax)/sqrt(2),path3d(list_rotate(trapezoid(ang=45,w1 = (r1adj+pmax)*sqrt(2), h = (r1adj+pmax)*fact,anchor=FWD),1),-l/2));
               trap2 = back((r2adj+pmax)/sqrt(2),path3d(list_rotate(trapezoid(ang=45,w1 = (r2adj+pmax)*sqrt(2), h = (r2adj+pmax)*fact,anchor=FWD),1), l/2));
@@ -2086,7 +2165,7 @@ module generic_threaded_rod(
                       [each cut2, each trap2]
               ];
               vnf_polyhedron(vnf_vertex_array(vert,caps=true,col_wrap=true));
-              //     Old code creates an internal teardrop which unfortunately doesn't print well
+              //     Old code creates an internal teardrop that unfortunately doesn't print well
               //ang = min(45,opp_hyp_to_ang(rmax+profmin, rmax+pmax));
               //xrot(-90) teardrop(l=l, r1=r1adj+profmin, r2=r2adj+profmin, ang=ang, cap_h1=r1adj+pmax, cap_h2=r2adj+pmax);
           }
@@ -2148,7 +2227,7 @@ module __rot_if_old()
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 function generic_threaded_nut(
     nutwidth,
@@ -2195,10 +2274,10 @@ module generic_threaded_nut(
     id1 = first_defined([id1,id]);
     id2 = first_defined([id2,id]);
     h = one_defined([h,height,thickness,l,length],"h,height,thickness,l,length");
-    dummyA = assert(is_num(pitch) && pitch>=0, "pitch must be a nonnegative number")
-             assert(is_num(h) && h>0, "height/thickness must be a positive number")
-             assert(in_list(shape,["square","hex"]), "shape must be \"hex\" or \"square\"")
-             assert(all_positive([id1,id2]), "Inner diameter(s) of nut must be positive number(s)");
+    dummyA = assert(is_num(pitch) && pitch>=0, "\npitch must be a nonnegative number.")
+             assert(is_num(h) && h>0, "\nheight/thickness must be a positive number.")
+             assert(in_list(shape,["square","hex"]), "\nshape must be \"hex\" or \"square\".")
+             assert(all_positive([id1,id2]), "\nInner diameter(s) of nut must be positive number(s).");
     slope = (id2-id1)/h;
     full_id1 = id1-slope*extra/2;
     full_id2 = id2+slope*extra/2;
@@ -2270,23 +2349,23 @@ module _nutshape(nutwidth, h, shape, bevel1, bevel2, bevang)
 //   to handle threads found in plastic and glass bottles.
 //   .
 //   You can specify a thread_depth and flank_angle, in which case you get a symmetric trapezoidal
-//   thread, whose inner diameter (the base of the threads for external threading) is d (so the
-//   total diameter will be d + thread_depth).  This differs from the threaded_rod modules, where
-//   the specified diameter is the outer diameter.  Alternatively you can give a profile, following
-//   the same rules as for general_threaded_rod.  The Y=0 point will align with the specified
-//   diameter, and the profile should range in X from -1/2 to 1/2.  You cannot specify both the
-//   profile and the thread_depth or flank_angle.
+//   thread, whose inner diameter (the base of the threads for external threading) is `d` (so the
+//   total diameter is `d + thread_depth`). This differs from the threaded_rod modules, where
+//   the specified diameter is the outer diameter. Alternatively you can give a profile, following
+//   the same rules as for general_threaded_rod.  The Y=0 point align1 with the specified
+//   diameter, and the profile should range in X from -1/2 to 1/2. You cannot specify both the
+//   profile and the `thread_depth` or `flank_angle`.
 //   .
 //   Unlike {{generic_threaded_rod()}, when internal=true this module generates the threads, not a thread mask.
 //   The profile needs to be inverted to produce the proper thread form.  If you use the built-in trapezoidal
 //   thread you get the inverted thread, designed so that the inner diameter is d.  If you supply a custom profile
 //   you must invert it yourself to get internal threads.  With adequate clearance
-//   this thread will mate with the thread that uses the same parameters but has internal=false.  Note that
-//   unlike the threaded_rod modules, thread_helix does not adjust the diameter for faceting, nor does it
-//   subtract any $slop for clearance.  
+//   this thread would mate with the thread that uses the same parameters but has `internal=false`.
+//   Unlike the threaded_rod modules, `thread_helix()` does not adjust the diameter for faceting, nor does it
+//   subtract any `$slop` for clearance.
 //   .
-//   The lead_in options specify a lead-in section where the ends of the threads scale down to avoid a sharp face at the thread ends.
-//   You can specify the length of this scaling directly with the lead_in parameters or as an angle using the lead_in_ang parameters.
+//   The `lead_in` options specify a lead-in section where the ends of the threads scale down to avoid a sharp face at the thread ends.
+//   You can specify the length of this scaling directly with the `lead_in` parameters or as an angle using the `lead_in_ang` parameters.
 //   If you give a positive value, the extrusion is lengthenend by the specified distance or angle; if you give a negative
 //   value then the scaled end is included in the extrusion length specified by `turns`.  If the value is zero then no scaled ends
 //   are produced.  The shape of the scaled ends can be controlled with the lead_in_shape parameter.  Supported options are "sqrt", "linear"
@@ -2345,12 +2424,12 @@ module _nutshape(nutwidth, h, shape, bevel1, bevel2, bevang)
 //   ---
 //   turns = Number of revolutions to rotate thread around.
 //   thread_depth = Depth of threads from top to bottom.
-//   flank_angle = Angle of thread faces to plane perpendicular to screw.  Default: 15 degrees.
+//   flank_angle = Angle of thread faces to plane perpendicular to screw. Default: 15°
 //   thread_angle = Angle between two thread faces.  
 //   profile = If an asymmetrical thread profile is needed, it can be specified here.
 //   starts = The number of thread starts.  Default: 1
 //   left_handed = If true, thread has a left-handed winding.
-//   internal = if true make internal threads.  The only effect this has is to change how the thread lead_in is constructed. When true, the lead-in section tapers towards the outside; when false, it tapers towards the inside.  Default: false
+//   internal = if true make internal threads.  The only effect this has is to change how the thread lead_in is constructed. When true, the lead-in section tapers toward the outside; when false, it tapers toward the inside.  Default: false
 //   d1 = Bottom inside base diameter of threads.
 //   d2 = Top inside base diameter of threads.
 //   lead_in = Specify linear length of the lead in section of the threading with blunt start threads
@@ -2363,7 +2442,7 @@ module _nutshape(nutwidth, h, shape, bevel1, bevel2, bevang)
 //   lead_in_sample = Factor to increase sample rate in the lead-in section.  Default: 10
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
 //   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
-//   orient = Vector to rotate top towards, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Example(2DMed): Typical Tooth Profile
 //   pitch = 2;
 //   depth = pitch * cos(30) * 5/8;
@@ -2399,13 +2478,13 @@ module thread_helix(
     lead_in_sample=10,
     anchor, spin, orient
 ) {
-    dummy1=assert(num_defined([thread_angle,flank_angle])<=1, "Cannot define both flank angle and thread angle")
+    dummy1=assert(num_defined([thread_angle,flank_angle])<=1, "\nCannot define both flank angle and thread angle.")
            assert(is_undef(profile) || !any_defined([thread_depth, flank_angle]),
-                  "Cannot give thread_depth or flank_angle with a profile")
-           assert(all_positive([turns]), "The turns parameter must be a positive number")
-           assert(all_positive(pitch), "pitch must be a positive number")
-           assert(num_defined([flank_angle,thread_angle])<=1, "Cannot give both thread_angle and flank_angle")
-           assert(is_def(profile) || is_def(thread_depth), "If profile is not given, must give thread depth");
+                  "\nCannot give thread_depth or flank_angle with a profile.")
+           assert(all_positive([turns]), "\nThe turns parameter must be a positive number.")
+           assert(all_positive(pitch), "\npitch must be a positive number.")
+           assert(num_defined([flank_angle,thread_angle])<=1, "\nCannot give both thread_angle and flank_angle.")
+           assert(is_def(profile) || is_def(thread_depth), "\nIf profile is not given, must give thread depth.");
     flank_angle = first_defined([flank_angle,u_mul(0.5,thread_angle),15]);
     h = pitch*starts*abs(turns);
     r1 = get_radius(d1=d1, d=d, dflt=10);
@@ -2416,7 +2495,7 @@ module thread_helix(
             dz = tdp * tan(flank_angle),
             cap = (1 - 2*dz)/2
         )
-        assert(cap/2+dz<=0.5, "Invalid geometry: incompatible thread depth and thread_angle/flank_angle")
+        assert(cap/2+dz<=0.5, "\nInvalid geometry: incompatible thread depth and thread_angle/flank_angle.")
         internal?
           [
             [-cap/2-dz, tdp],

--- a/threading.scad
+++ b/threading.scad
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////
 // LibFile: threading.scad
 //   Provides generic threading support and specialized support for standard triangular (UTS/ISO) threading,
-//   trapezoidal threading (ACME), pipe threading, buttress threading, square threading and ball screws.  
+//   trapezoidal threading (ACME), hose couplers, pipe threading, buttress threading, square threading and ball screws.  
 // Includes:
 //   include <BOSL2/std.scad>
 //   include <BOSL2/threading.scad>

--- a/threading.scad
+++ b/threading.scad
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////
 // LibFile: threading.scad
 //   Provides generic threading support and specialized support for standard triangular (UTS/ISO) threading,
-//   trapezoidal threading (ACME), hose couplers, pipe threading, buttress threading, square threading and ball screws.  
+//   trapezoidal threading (ACME), garden hose couplers, pipe threading, buttress threading, square threading and ball screws.
 // Includes:
 //   include <BOSL2/std.scad>
 //   include <BOSL2/threading.scad>
@@ -285,7 +285,7 @@ module threaded_rod(
 // Arguments:
 //   nutwidth = flat to flat width of nut
 //   id = inner diameter of threaded hole, measured from bottom of threads
-//   h / height / l / length / thickness = height/thickness of nut.
+//   h / height / l / length / thickness = height/thickness of nut. Only `h` is positional, others must be named.
 //   pitch = Distance between threads, or zero for no threads. 
 //   ---
 //   shape = specifies shape of nut, either "hex" or "square".  Default: "hex"
@@ -347,8 +347,7 @@ module threaded_nut(
 ) {
     dummy1=
           assert(all_nonnegative(pitch), "\nNut pitch must be nonnegative.")
-          assert(all_positive(id), "\nNut inner diameter must be positive.")
-          assert(all_positive(h),"\nNut thickness must be positive.");
+          assert(all_positive(id), "\nNut inner diameter must be positive.");
     basic = is_num(id) || is_undef(id) || is_def(id1) || is_def(id2);
     dummy2 = assert(basic || is_vector(id,3));
     depth = basic ? cos(30) * 5/8
@@ -961,13 +960,103 @@ module acme_threaded_nut(
 //   In other countries, a British Standard Pipe (BSP) thread is used, which is 14 TPI, not compatible with the GHT standard. These modules implement the GHT standard.
 
 
-// Module: male_garden_hose()
+// Module: garden_hose_threaded_rod()
+// Synopsis: Creates a threaded rod compatible with the North American garden hose thread.
+// SynTags: Geom
+// Topics: Threading, Screws
+// See Also: garden_hose_threaded_nut()
+// Usage:
+//   garden_hose_threaded_rod(d, l|length, [internal=], ...) [ATTACHMENTS];
+// Description:
+//   Constructs a threaded rod compatible with 3/4-11.5NH garden hose threads as described by ANSI-ASME B1.20.7.
+//   .
+// Arguments:
+//   l / length / h / height = Length of threaded rod. Only `l` is positional, others must be named.
+//   ---
+//   bevel = Sets bevel for both ends. Set to true for default size, a number to specify a bevel size, false for no bevel, and "reverse" for an inverted bevel. Default: false for blunt start ends, true otherwise
+//   bevel1 = Set bevel for bottom end.
+//   bevel2 = Set bevel for top end. 
+//   internal = If true, make this a mask for making internal threads.  Default: false
+//   blunt_start = If true apply truncated blunt start threads at both ends.  Default: true
+//   blunt_start1 = If true apply truncated blunt start threads bottom end.
+//   blunt_start2 = If true apply truncated blunt start threads top end.
+//   end_len = Specify the unthreaded length at the end after blunt start threads.  Default: 0
+//   end_len1 = Specify unthreaded length at the bottom
+//   end_len2 = Specify unthreaded length at the top
+//   lead_in = Specify linear length of the lead in section of the threading with blunt start threads
+//   lead_in1 = Specify linear length of the lead in section of the threading at the bottom with blunt start threads
+//   lead_in2 = Specify linear length of the lead in section of the threading at the top with blunt start threads
+//   lead_in_ang = Specify angular length in degrees of the lead in section of the threading with blunt start threads
+//   lead_in_ang1 = Specify angular length in degrees of the lead in section of the threading at the bottom with blunt start threads
+//   lead_in_ang2 = Specify angular length in degrees of the lead in section of the threading at the top with blunt start threads
+//   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
+//   teardrop = If true, adds a teardrop profile to the back (Y+) side of the threaded rod, for 3d printability of horizontal holes. If numeric, specifies the proportional extra distance of the teardrop flat top from the screw center, or set to "max" for a pointed teardrop. Default: false
+//   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
+//   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
+//   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
+// Example: Garden hose threaded rod of arbitrary length.
+//   garden_hose_threaded_rod(l=25, $fn=60);
+function garden_hose_threaded_rod(
+    l,
+    bevel,bevel1,bevel2,
+    internal=false,
+    length, h, height,
+    blunt_start, blunt_start1, blunt_start2,
+    lead_in, lead_in1, lead_in2,
+    lead_in_ang, lead_in_ang1, lead_in_ang2,
+    end_len, end_len1, end_len2,
+    lead_in_shape="default",
+    teardrop=false,
+    anchor, spin, orient
+) = no_function("garden_hose_threaded_rod");
+module garden_hose_threaded_rod(
+    l,
+    bevel,bevel1,bevel2,
+    internal=false,
+    length, h, height,
+    blunt_start, blunt_start1, blunt_start2,
+    lead_in, lead_in1, lead_in2,
+    lead_in_ang, lead_in_ang1, lead_in_ang2,
+    end_len, end_len1, end_len2,
+    lead_in_shape="default",
+    teardrop=false,
+    anchor, spin, orient
+) {
+    thread_angle = 60;
+    tpi = 11.5;
+    pitch = 1/tpi * INCH;
+    thread_depth = 0.649519*pitch;
+    d = (1 + 1/16 + (internal ? 0.01 : 0)) * INCH; // 1.0625" external, 1.0725" internal
+    pa_delta = 0.5*thread_depth*tan(thread_angle/2) / pitch;
+    rr1 = -thread_depth/pitch;
+    z1 = 1/4-pa_delta;
+    z2 = 1/4+pa_delta;
+    profile = [
+               [-z2, rr1],
+               [-z1,  0],
+               [ z1,  0],
+               [ z2, rr1],
+              ];
+    generic_threaded_rod(d=d,l=l,pitch=pitch,profile=profile,
+        left_handed=false,bevel=bevel,bevel1=bevel1,bevel2=bevel2,starts=1,
+        internal=internal, length=length, height=height, h=h,
+        blunt_start=blunt_start, blunt_start1=blunt_start1, blunt_start2=blunt_start2,
+        lead_in=lead_in, lead_in1=lead_in1, lead_in2=lead_in2, lead_in_shape=lead_in_shape,
+        lead_in_ang=lead_in_ang, lead_in_ang1=lead_in_ang1, lead_in_ang2=lead_in_ang2,
+        end_len=end_len, end_len1=end_len1, end_len2=end_len2,
+        teardrop=teardrop, anchor=anchor,spin=spin,orient=orient)
+      children();
+}
+
+
+// Module: garden_hose_male()
 // Synopsis: Creates a male garden hose coupler
 // SynTags: Geom
 // Topics: Threading
-// See Also: female_garden_hose()
+// See Also: garden_hose_female()
 // Usage:
-//   male_garden_hose([wall], ...) [ATTACHMENTS];
+//   garden_hose_male([wall], ...) [ATTACHMENTS];
 // Description:
 //   Constructs a standard male coupler compatible with a standard North American garden hose, using ANSI-ASME B1.20.7 specifications.
 //   The `wall` thickness default is set to give the coupler an inner diameter of 25/32" according to the spec.
@@ -979,15 +1068,13 @@ module acme_threaded_nut(
 //   spin = Rotate this many degrees around the Z axis after anchor. See [spin](attachments.scad#subsection-spin).  Default: 0
 //   orient = Vector to rotate top toward, after spin. See [orient](attachments.scad#subsection-orient). Default: `UP`
 // Example:
-//   male_garden_hose();
+//   garden_hose_male();
 
-module male_garden_hose(wall=2.13729, anchor=BOTTOM, spin=0, orient=UP) {
+function garden_hose_male(wall, anchor, spin, orient) = no_function("garden_hose_male");
+module garden_hose_male(wall=2.13729, anchor=BOTTOM, spin=0, orient=UP) {
     tpi = 11.5;
     pitch = 1/tpi * INCH;
     thread_depth = 0.649519*pitch;
-
-    // make nipple (male end)
-
     dia_male = (1 + 1/16) * INCH; // 1.0625"
     pilot = 1/8 * INCH;
     nipple_len = 9/16 * INCH;
@@ -996,9 +1083,8 @@ module male_garden_hose(wall=2.13729, anchor=BOTTOM, spin=0, orient=UP) {
 
     attachable(anchor, spin, orient, d=dia_male, l=nipple_len) {
         difference() {
-            trapezoidal_threaded_rod(d=dia_male, l=nipple_len, pitch=pitch,
-                thread_depth=thread_depth, thread_angle=60,
-                end_len2=pilot, bevel2=0.2, lead_in_ang2=44, anchor=CENTER);
+            //garden_hose_threaded_rod(l=nipple_len, end_len2=pilot, bevel2=0.2, lead_in_ang2=44, anchor=CENTER);
+            trapezoidal_threaded_rod(d=dia_male, l=nipple_len, pitch=pitch, thread_depth=thread_depth, thread_angle=60, end_len2=pilot, bevel2=0.2, lead_in_ang2=44, anchor=CENTER);
             cylinder(nipple_len+0.2, d=nipple_inside_dia, center=true);
         }
         children();
@@ -1006,38 +1092,71 @@ module male_garden_hose(wall=2.13729, anchor=BOTTOM, spin=0, orient=UP) {
 }
 
 
-// Module: female_garden_hose()
+/// Internal function: _tex_cyl()
+/// Called by garden_hose_female() and bottle cap functions in bottlecaps.scad,
+/// to generate a cylinder with an optional knurling texture.
+/// All textures expand the diameter due to not reducing the original wall thickness.
+/// w = diameter, hh = height, texture=one of 5 choices, anchor=cylinder anchor end, modname=calling module
+module _tex_cyl(w, hh, texture, anchor, modname) {
+    if (texture == "knurled")
+        cyl(d=w, h=hh, texture="trunc_pyramids", tex_size=[3,3], style="convex", anchor=anchor);
+    else if (texture == "sharp_knurled")
+        cyl(d=w, h=hh, texture="diamonds", tex_size=[3,3], style="concave", anchor=anchor);
+    else if (texture == "ribbed")
+        cyl(d=w, h=hh, texture="trunc_ribs", tex_size=[3,3], /*chamfer2=.8,*/ tex_taper=0, style="min_edge", anchor=anchor); // removed chamfer to preserve wall thickness
+    else if (texture == "sharp_ribbed")
+        cyl(d=w, h=hh, texture="ribs", tex_size=[3,3], style="min_edge", anchor=anchor);
+    else if (texture == "hex_faces")
+        let(cd = w/cos(30), dmid = (w + cd)/2) intersection() {
+            cyl(d=cd, l=hh, anchor=anchor, $fn=6);
+            cyl(d=dmid, l=hh, chamfer=(cd-dmid)/2+0.4, chamfang=40, anchor=anchor);
+        }
+    else {
+        if (texture != "none") echo(str("WARNING: Unrecognized texture value \"", texture, "\" in ", modname, "(). Defaulting to \"none\"."));
+        cyl(d=w, l=hh, anchor=anchor);
+    }
+}
+
+
+// Module: garden_hose_female()
 // Synopsis: Creates a female garden hose coupler with textured surface
 // SynTags: Geom
 // Topics: Threading
-// See Also: male_garden_hose()
+// See Also: garden_hose_female()
 // Usage:
-//   female_garden_hose([gasket_seat], [wall=], [texture=], ...) [ATTACHMENTS];
+//   garden_hose_female([gasket_seat], [wall=], [texture=], ...) [ATTACHMENTS];
 // Description:
-//   Constructs a female hose coupler compatible with a standard North American garden hose, using ANSI-ASME B1.20.7 specifications for the threads, with space to accommodate a rubber gasket assuming a standard 25/32" inner diameter.
-//   The mating male coupler, if created with `male_garden_hose()`, may have a smaller inner diameter, which would still completely cover the gasket.
+//   Constructs a female hose coupler compatible with a standard North American garden hose, using [ANSI-ASME B1.20.7 specifications](https://web.archive.org/web/20170826074605/http://gost-snip.su/download/asme_b1_20_7i991_hose_coupling_screw_threads_inch)
+//   for the threads, with space to accommodate a rubber gasket assuming a standard 25/32" inner diameter.
+//   The mating male coupler, if created with `garden_hose_male()`, may have a smaller inner diameter, which would still completely cover the gasket.
 //   .
 //   For structural integrity when 3D printing, the `wall` and `gasket_seat` parameters have arbitrary but reasonable default values. The larger these values, the stronger the part.
 //   .
 //   This design does not include a slip joint between the rotating collar and the pipe that seals against the gasket. The coupler consists of only a rotating collar that seals against the gasket, which should be lubricated with silicone grease to allow the gasket to slide between the male and female coupler while tightening.
 // Arguments:
 //   gasket_seat = thickness of structure that the rubber sealing gasket rests on. Default: 5
+//   addl_space = Millimeters of additional space between the threads and gasket seat, to accommodate a swivel tube with a brim. Default: 0
 //   wall = wall thickness around the thread outer diameter. Default: 5
-//   texture = texture for outside of coupler, one of "knurled", "ribbed" or "none.  Default: "none"
+//   texture = texture for outside of coupler, one of "knurled", "ribbed", "sharp_ribbed", "hex_faces", or "none". Default: "none"
 //   anchor = Translate so anchor point is at origin (0,0,0). See [anchor](attachments.scad#subsection-anchor).  Default: `BOTTOM`
 //   spin = Rotate this many degrees around the Z axis after anchor. See [spin](attachments.scad#subsection-spin).  Default: 0
 //   orient = Vector to rotate top toward, after spin. See [orient](attachments.scad#subsection-orient). Default: `UP`
-// Example:
-//   female_garden_hose(texture="ribbed");
+// Example(Med;NoAxes;VPD=230;VPT=[0,0,9]): Female garden hose connectors with different finishes. Clockwise from top: knurled, sharp_knurled, ribbed, sharp_ribbed. Center: hex_faces.
+//   $fn = 48;
+//   back(40) garden_hose_female(texture="knurled");
+//   right(40) garden_hose_female(texture="sharp_knurled");
+//   fwd(40) garden_hose_female(texture="ribbed");
+//   left(40) garden_hose_female(texture="sharp_ribbed");
+//   garden_hose_female(texture="hex_faces");
 
-
-module female_garden_hose(gasket_seat=5, wall=5, texture="none", anchor=BOTTOM, spin=0, orient=UP) {
+function garden_hose_female(gasket_seat, addl_space, wall, texture, anchor, spin, orient) = no_function("garden_hose_female");
+module garden_hose_female(gasket_seat=5, addl_space=0, wall=5, texture="none", anchor=BOTTOM, spin=0, orient=UP) {
     tpi = 11.5;
     pitch = 1/tpi * INCH;
     thread_depth = 0.649519*pitch;
     nipple_inside_dia = 25/32 * INCH;
     dia_female = (1 + 1/16 + 0.01) * INCH; // 1.0725" in the spec
-    coupling_len = 17/32 * INCH;
+    coupling_len = 17/32 * INCH + addl_space;
     coupling_thread_len = 3/8 * INCH;
     gasket_space = coupling_len - coupling_thread_len;
     coupling_total_len = coupling_len + gasket_seat;
@@ -1045,22 +1164,53 @@ module female_garden_hose(gasket_seat=5, wall=5, texture="none", anchor=BOTTOM, 
 
     attachable(anchor, spin, orient, d=total_dia, l=coupling_total_len) {
         xrot(180) down(coupling_total_len/2) difference() {
-            if (texture=="knurled")
-                cyl(d=total_dia, l=coupling_total_len, center=false, texture="trunc_pyramids", tex_size=[3,3], style="convex");
-            else if (texture == "ribbed")
-                cyl(d=total_dia, l=coupling_total_len, center=false, chamfer2=.8, tex_taper=0, texture="trunc_ribs", tex_size=[3,3], style="min_edge");
-            else
-                cyl(d=total_dia, l=coupling_total_len, center=false);
-            //cylinder(coupling_total_len, d=total_dia);
+            _tex_cyl(total_dia, coupling_total_len, texture, BOTTOM, "garden_hose_female");
             down(0.2) cylinder(coupling_total_len+0.4, d=nipple_inside_dia+1);
-            down(0.1) trapezoidal_threaded_rod(d=dia_female, l=coupling_len+0.1, pitch=pitch,
-                thread_depth=thread_depth, thread_angle=60, internal=true,
-                end_len1=0.1, end_len2=gasket_space, lead_in_ang1=38, anchor=BOTTOM);
+            down(0.1)
+                garden_hose_threaded_rod(l=coupling_len+0.1, internal=true, end_len1=0.1, end_len2=gasket_space, lead_in_ang1=38, anchor=BOTTOM);
         }
         children();
     }
 }
 
+
+// Module: garden_hose_gasket()
+// Synopsis: Creates a North American garden hose washer or gasket
+// SynTags: Geom
+// Topics: Threading
+// See Also: garden_hose_female()
+// Usage:
+//   garden_hose_gasket([od=], [id=], [thickness=]) [ATTACHMENTS];
+// Description:
+//   Constructs a garden hose washer that fits inside a female hose coupler compatible with a standard North American garden hose. This would typically be 3D printed using TPU or another waterproof flexible material.
+// Arguments:
+//   od = Outer diameter, normally 1" converted to millimeters. Default: 25.4
+//   id = Inner diameter, normally 5/8" converted to millimeters. Default: 15.875
+//   thickness = Normally 1/8" thick, converted to millimeters. Default: 3
+//   anchor = Translate so anchor point is at origin (0,0,0). See [anchor](attachments.scad#subsection-anchor).  Default: `BOTTOM`
+//   spin = Rotate this many degrees around the Z axis after anchor. See [spin](attachments.scad#subsection-spin).  Default: 0
+//   orient = Vector to rotate top toward, after spin. See [orient](attachments.scad#subsection-orient).
+// Example:
+//   garden_hose_gasket();
+// Example(Med;NoAxes;VPD=87;VPR=[110,0,116];VPT=[0,0,10]): Cut-away assembly view of male hose connector (yellow), female hose connector (green), and hose gasket (brown).
+//   $fn = 60;
+//   color("lightgreen") difference() {
+//       garden_hose_female(texture="knurled");
+//       down(3) cube(25);
+//   }
+//   color("brown") up(5) garden_hose_gasket();
+//   up(8.01) zrot(60) xrot(180) garden_hose_male(anchor=TOP);
+
+function garden_hose_gasket(od, id, thickness, anchor, spin, orient) = no_function("garden hose gasket");
+module garden_hose_gasket(od=25.4, id=15.875, thickness=3, anchor=BOTTOM, spin=0, orient=UP) {
+    attachable(anchor, spin, orient, d=od, l=thickness) {
+        difference() {
+            cylinder(thickness, d=od, center=true, $fa=4);
+            cylinder(thickness+0.1, d=id, center=true, $fa=4);
+        }
+        children();
+    }
+}
 
 
 

--- a/threading.scad
+++ b/threading.scad
@@ -174,7 +174,7 @@ _BOSL2_THREADING = is_undef(_BOSL2_STD) && (is_undef(BOSL2_NO_STD_WARNING) || !B
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
 //   teardrop = If true, adds a teardrop profile to the back (Y+) side of the threaded rod, for 3d printability of horizontal holes. If numeric, specifies the proportional extra distance of the teardrop flat top from the screw center, or set to "max" for a pointed teardrop. Default: false
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Example(2D):
@@ -312,7 +312,7 @@ module threaded_rod(
 //   lead_in_ang2 = Specify angular length in degrees of the lead in section of the threading at the top with blunt start threads
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Examples(Med):
@@ -477,7 +477,7 @@ module threaded_nut(
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
 //   teardrop = If true, adds a teardrop profile to the back (Y+) side of the threaded rod, for 3d printability of horizontal holes. If numeric, specifies the proportional extra distance of the teardrop flat top from the screw center, or set to "max" for a pointed teardrop. Default: false
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Example(2D): A threaded rod profile.
@@ -546,52 +546,6 @@ module threaded_nut(
 //         teardrop=true, orient=FWD
 //     );
 //   }
-// Example(Med): Garden hose threads on male and female connectors (cross section view) using specifications from ASME B1.20.7-1991
-//   tpi = 11.5;  // threads per inch
-//   pitch = 1/tpi * INCH;
-//   thread_depth = 0.649519*pitch;
-//   $fn=64;
-//   
-//   // make nipple (male end)
-//   
-//   dia_male = (1 + 1/16) * INCH; // 1.0625"
-//   pilot = 1/8 * INCH;
-//   nipple_len = 9/16 * INCH;
-//   nipple_inside_dia = 25/32 * INCH;
-//   
-//   color("gold") down(pitch) difference() {
-//       zrot(195) trapezoidal_threaded_rod(d=dia_male,
-//           l=nipple_len, pitch=pitch,
-//           thread_depth=thread_depth, thread_angle=60,
-//           end_len2=pilot, bevel2=0.2, lead_in_ang2=44,
-//           anchor=BOTTOM);
-//       down(0.1) cylinder(nipple_len+0.2, d=nipple_inside_dia);
-//       translate([0.1,-20.1,-1]) cube(25); // cut section
-//   }
-//   
-//   // make coupling (female end)
-//   
-//   dia_female = (1 + 1/16 + 0.01) * INCH; // 1.0725"
-//   coupling_len = 17/32 * INCH;
-//   coupling_thread_len = 3/8 * INCH;
-//   gasket_space = coupling_len - coupling_thread_len;
-//   wall = 5;  // arbitrary, make bigger, add knurl, etc.
-//   gasket_seat_thickness = 6; // arbitrary
-//   coupling_total_len = coupling_len + gasket_seat_thickness;
-//   
-//   color("silver") difference() {
-//       cylinder(coupling_len+gasket_seat_thickness,
-//           d=dia_female+2*wall);
-//       down(0.2) cylinder(coupling_total_len+0.4,
-//           d=nipple_inside_dia+1);
-//       down(0.1) trapezoidal_threaded_rod(d=dia_female,
-//           l=coupling_len+0.1, pitch=pitch,
-//           thread_depth=thread_depth, thread_angle=60,
-//           internal=true, end_len1=0.1, end_len2=gasket_space,
-//           lead_in_ang1=38, anchor=BOTTOM);
-//       translate([0,-20,-1]) cube(25); // cut section
-//   }
-
 function trapezoidal_threaded_rod(
     d, l, pitch,
     thread_angle,
@@ -703,7 +657,7 @@ module trapezoidal_threaded_rod(
 //   lead_in_ang2 = Specify angular length in degrees of the lead in section of the threading at the top with blunt start threads
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Examples(Med):
@@ -825,7 +779,7 @@ module trapezoidal_threaded_nut(
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
 //   teardrop = If true, adds a teardrop profile to the back (Y+) side of the threaded rod, for 3d printability of horizontal holes. If numeric, specifies the proportional extra distance of the teardrop flat top from the screw center, or set to "max" for a pointed teardrop. Default: false
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Example(2D):
@@ -937,7 +891,7 @@ module acme_threaded_rod(
 //   lead_in_ang2 = Specify angular length in degrees of the lead in section of the threading at the top with blunt start threads
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Examples(Med):
@@ -1000,6 +954,116 @@ module acme_threaded_nut(
 
 
 
+// Section: Garden hose connectors
+//   The GHT ("garden hose thread") standard in the United States, its territories, and Canada uses the NH ("National Hose") designation. Specifically, the 3/4-11.5NH threads are full form threads produced by cutting threads in metal. A compatible standard 3/4-11.5NHR designates thin-walled couplers produced by rolling thin material, usually brass, typically found on cheaper hoses.
+//   .
+//   For the 3/4-11.5NH garden hose threads, ANSI-ASME B1.20.7 specifies a non-tapered thread 1+1/16 inches (27 mm) in diameter with a pitch of 11.5 threads per inch (TPI).
+//   In other countries, a British Standard Pipe (BSP) thread is used, which is 14 TPI, not compatible with the GHT standard. These modules implement the GHT standard.
+
+
+// Module: male_garden_hose()
+// Synopsis: Creates a male garden hose coupler
+// SynTags: Geom
+// Topics: Threading
+// See Also: female_garden_hose()
+// Usage:
+//   male_garden_hose([wall], ...) [ATTACHMENTS];
+// Description:
+//   Constructs a standard male coupler compatible with a standard North American garden hose, using ANSI-ASME B1.20.7 specifications.
+//   The `wall` thickness default is set to give the coupler an inner diameter of 25/32" according to the spec.
+//   This results in a wall thickness sligtly over 2 mm, creating a ring-shaped surface that compresses a rubber gasket in the mating female coupler.
+//   For structural integrity when 3D printing, you may want to make the wall thickness thicker, which would reduce the inner diameter and flow rate through the coupler.
+// Arguments:
+//   wall = wall thickness inside the inner thread diameter. Default = 2.13729
+//   anchor = Translate so anchor point is at origin (0,0,0). See [anchor](attachments.scad#subsection-anchor).  Default: `BOTTOM`
+//   spin = Rotate this many degrees around the Z axis after anchor. See [spin](attachments.scad#subsection-spin).  Default: 0
+//   orient = Vector to rotate top toward, after spin. See [orient](attachments.scad#subsection-orient). Default: `UP`
+// Example:
+//   male_garden_hose();
+
+module male_garden_hose(wall=2.13729, anchor=BOTTOM, spin=0, orient=UP) {
+    tpi = 11.5;
+    pitch = 1/tpi * INCH;
+    thread_depth = 0.649519*pitch;
+
+    // make nipple (male end)
+
+    dia_male = (1 + 1/16) * INCH; // 1.0625"
+    pilot = 1/8 * INCH;
+    nipple_len = 9/16 * INCH;
+    thread_inside_dia = dia_male - 2*thread_depth;
+    nipple_inside_dia = thread_inside_dia - 2*wall; // should default 25/32 * INCH;
+
+    attachable(anchor, spin, orient, d=dia_male, l=nipple_len) {
+        difference() {
+            trapezoidal_threaded_rod(d=dia_male, l=nipple_len, pitch=pitch,
+                thread_depth=thread_depth, thread_angle=60,
+                end_len2=pilot, bevel2=0.2, lead_in_ang2=44, anchor=CENTER);
+            cylinder(nipple_len+0.2, d=nipple_inside_dia, center=true);
+        }
+        children();
+    }
+}
+
+
+// Module: female_garden_hose()
+// Synopsis: Creates a female garden hose coupler with textured surface
+// SynTags: Geom
+// Topics: Threading
+// See Also: male_garden_hose()
+// Usage:
+//   female_garden_hose([gasket_seat], [wall=], [texture=], ...) [ATTACHMENTS];
+// Description:
+//   Constructs a female hose coupler compatible with a standard North American garden hose, using ANSI-ASME B1.20.7 specifications for the threads, with space to accommodate a rubber gasket assuming a standard 25/32" inner diameter.
+//   The mating male coupler, if created with `male_garden_hose()`, may have a smaller inner diameter, which would still completely cover the gasket.
+//   .
+//   For structural integrity when 3D printing, the `wall` and `gasket_seat` parameters have arbitrary but reasonable default values. The larger these values, the stronger the part.
+//   .
+//   This design does not include a slip joint between the rotating collar and the pipe that seals against the gasket. The coupler consists of only a rotating collar that seals against the gasket, which should be lubricated with silicone grease to allow the gasket to slide between the male and female coupler while tightening.
+// Arguments:
+//   gasket_seat = thickness of structure that the rubber sealing gasket rests on. Default: 5
+//   wall = wall thickness around the thread outer diameter. Default: 5
+//   texture = texture for outside of coupler, one of "knurled", "ribbed" or "none.  Default: "none"
+//   anchor = Translate so anchor point is at origin (0,0,0). See [anchor](attachments.scad#subsection-anchor).  Default: `BOTTOM`
+//   spin = Rotate this many degrees around the Z axis after anchor. See [spin](attachments.scad#subsection-spin).  Default: 0
+//   orient = Vector to rotate top toward, after spin. See [orient](attachments.scad#subsection-orient). Default: `UP`
+// Example:
+//   female_garden_hose(texture="ribbed");
+
+
+module female_garden_hose(gasket_seat=5, wall=5, texture="none", anchor=BOTTOM, spin=0, orient=UP) {
+    tpi = 11.5;
+    pitch = 1/tpi * INCH;
+    thread_depth = 0.649519*pitch;
+    nipple_inside_dia = 25/32 * INCH;
+    dia_female = (1 + 1/16 + 0.01) * INCH; // 1.0725" in the spec
+    coupling_len = 17/32 * INCH;
+    coupling_thread_len = 3/8 * INCH;
+    gasket_space = coupling_len - coupling_thread_len;
+    coupling_total_len = coupling_len + gasket_seat;
+    total_dia = dia_female + 2*wall;
+
+    attachable(anchor, spin, orient, d=total_dia, l=coupling_total_len) {
+        xrot(180) down(coupling_total_len/2) difference() {
+            if (texture=="knurled")
+                cyl(d=total_dia, l=coupling_total_len, center=false, texture="trunc_pyramids", tex_size=[3,3], style="convex");
+            else if (texture == "ribbed")
+                cyl(d=total_dia, l=coupling_total_len, center=false, chamfer2=.8, tex_taper=0, texture="trunc_ribs", tex_size=[3,3], style="min_edge");
+            else
+                cyl(d=total_dia, l=coupling_total_len, center=false);
+            //cylinder(coupling_total_len, d=total_dia);
+            down(0.2) cylinder(coupling_total_len+0.4, d=nipple_inside_dia+1);
+            down(0.1) trapezoidal_threaded_rod(d=dia_female, l=coupling_len+0.1, pitch=pitch,
+                thread_depth=thread_depth, thread_angle=60, internal=true,
+                end_len1=0.1, end_len2=gasket_space, lead_in_ang1=38, anchor=BOTTOM);
+        }
+        children();
+    }
+}
+
+
+
+
 // Section: Pipe Threading
 
 // Module: npt_threaded_rod()
@@ -1024,7 +1088,7 @@ module acme_threaded_nut(
 //   hollow = If true, create a pipe with the correct internal diameter.
 //   internal = If true, make this a mask for making internal threads.
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Example(2D): The straight gray rectangle reveals the tapered threads.  
@@ -1162,7 +1226,7 @@ module npt_threaded_rod(
 //   lead_in_ang2 = Specify angular length in degrees of the lead in section of the threading at the top with blunt start threads
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Examples(Med):
@@ -1318,7 +1382,7 @@ module bspp_threaded_rod(
 //   d1 = Bottom outside diameter of threads.
 //   d2 = Top outside diameter of threads.
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Example(2D):
@@ -1432,7 +1496,7 @@ module buttress_threaded_rod(
 //   lead_in_ang2 = Specify angular length in degrees of the lead in section of the threading at the top with blunt start threads
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Examples(Med):
@@ -1532,7 +1596,7 @@ module buttress_threaded_nut(
 //   d1 = Bottom outside diameter of threads.
 //   d2 = Top outside diameter of threads.
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Example(2D):
@@ -1640,7 +1704,7 @@ module square_threaded_rod(
 //   lead_in_ang2 = Specify angular length in degrees of the lead in section of the threading at the top with blunt start threads
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Examples(Med):
@@ -1735,7 +1799,7 @@ module square_threaded_nut(
 //   lead_in_ang2 = Specify angular length in degrees of the lead in section of the threading at the top with blunt start threads
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Example(2D): Thread Profile, ball_diam=4, ball_arc=100
@@ -1869,7 +1933,7 @@ module ball_screw_rod(
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
 //   teardrop = If true, adds a teardrop profile to the back (Y+) side of the threaded rod, for 3d printability of horizontal holes. If numeric, specifies the proportional extra distance of the teardrop flat top from the screw center, or set to "max" for a pointed teardrop (see above). Default: false
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 // Example(2DMed,VPD=1.92,VPT=[0.00,-0.30,2.5]): Example Tooth Profile.  Note that the X range of the profile must be in [-1/2,1/2] because the profile is scaled up by the pitch to produce the final thread profile.  
@@ -2226,7 +2290,7 @@ module __rot_if_old()
 //   lead_in_ang2 = Specify angular length in degrees of the lead in section of the threading at the top with blunt start threads
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "default"
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 //   $slop = The printer-specific slop value, which adds clearance (`4*$slop`) to internal threads.
 function generic_threaded_nut(
@@ -2441,7 +2505,7 @@ module _nutshape(nutwidth, h, shape, bevel1, bevel2, bevang)
 //   lead_in_shape = Specify the shape of the thread lead in by giving a text string or function.  Default: "sqrt"
 //   lead_in_sample = Factor to increase sample rate in the lead-in section.  Default: 10
 //   anchor = Translate so anchor point is at origin (0,0,0).  See [anchor](attachments.scad#subsection-anchor).  Default: `CENTER`
-//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin).  Default: `0`
+//   spin = Rotate this many degrees around the Z axis after anchor.  See [spin](attachments.scad#subsection-spin). Default: 0
 //   orient = Vector to rotate top toward, after spin.  See [orient](attachments.scad#subsection-orient).  Default: `UP`
 // Example(2DMed): Typical Tooth Profile
 //   pitch = 2;


### PR DESCRIPTION
Changes to threading.scad:
* Added support for garden hose male and female couplers; new modules `garden_hose_threaded_rod()`, `garden_hose_male()`, `garden_hose_female()`, and `garden_hose_gasket()`
* Added module to generate a cylinder with consistent knurling types, now called by `garden_hose_female()` as well as all of the `...cap()` modules in bottlecaps.scad
* Knurling types are now:
  * `knurled` (trunc_pyramids)
  * `sharp_knurled` (diamonds)
  * `ribbed` (trunc_ribs)
  * `sharp_ribbed` (ribs)
  * `hex_faces` (rounded nut shape)
* Added descriptions for several examples in `trapezoidal_threaded_rod()`
* Corrected documentation inconsistencies (e.g. default `anchor` in docs disagreed with actual default in code)
* Prefixed all assert messages with newlines
* Minor copyediting of docs for grammar and spelling

Changes to bottlecaps.scad:
* Added support for Mason jar necks and caps; new modules `mason_neck()` and `mason_cap()`.
* Added some introductory text to some sections, giving brief descriptions of the standards
* Several module parameters had undocumented defaults; added these values to the docs
* Changed arbitrary default values in cap/neck adapter modules to use PCO1881 where applicable, and documented this
* Reviewed all anchor defaults for sensibility
* Prefixed all assert messages with newlines
* Minor copyediting of docs for grammar and spelling