### PR TITLE
fix: face_profile() used wrong corner mask axis for non-TOP/BOTTOM faces

### DIFF
--- a/masks.scad
+++ b/masks.scad
@@ -1172,8 +1172,16 @@ module face_profile(faces=[], r, d, excess=0.01, convexity=10) {
     assert(all([for (face=faces) is_vector(face) && sum([for (x=face) x!=0? 1 : 0])==1]), "\nVector in faces doesn't point at a face.");
     r = get_radius(r=r, d=d, dflt=undef);
     assert(is_num(r) && r>=0);
+    axis = let(
+        nx = [for (f=faces) if (!approx(f.x,0)) true],
+        ny = [for (f=faces) if (!approx(f.y,0)) true],
+        nz = [for (f=faces) if (!approx(f.z,0)) true]
+    ) len(nx)==0 && len(ny)==0 ? "Z"
+      : len(ny)==0 && len(nz)==0 ? "X"
+      : len(nx)==0 && len(nz)==0 ? "Y"
+      : "Z";
     edge_profile(faces, excess=excess) children();
-    corner_profile(faces, convexity=convexity, r=r) children();
+    corner_profile(faces, convexity=convexity, r=r, axis=axis) children();
 }
 
 


### PR DESCRIPTION
## Problem

`face_profile()` does not pass `axis` to `corner_profile()`, so the corner mask is always revolved around the Z axis regardless of which face is being masked. For TOP/BOTTOM faces this happens to be correct, but for FRONT/BACK and LEFT/RIGHT faces the revolution axis does not align with the masked face's normal, so the corner mask blends the wrong pair of edges. This breaks the expected cuboid symmetry: profiling TOP, FRONT, or LEFT of an identical cube with the same 2D profile produces visibly different results.

Minimal repro:

```openscad
include <BOSL2/std.scad>
$fn = 64;
diff() cuboid([60,60,60], anchor=BOTTOM)
    face_profile(TOP, r=10) mask2d_chamfer(1);

left(100) diff() cuboid([60,60,60], anchor=TOP)
    face_profile(FRONT, r=10) mask2d_chamfer(1);

left(200) diff() cuboid([60,60,60], anchor=BOTTOM)
    face_profile(LEFT, r=10) mask2d_chamfer(1);
```

The three cubes should be identical up to rotation, but FRONT and LEFT render incorrectly.

## Root cause

The corner mask is produced by `rotate_extrude()` of the 2D profile, so the revolution axis must coincide with the masked face's normal:

| Face          | Required `axis` |
|---------------|-----------------|
| TOP / BOTTOM  | `"Z"`           |
| FRONT / BACK  | `"Y"`           |
| LEFT / RIGHT  | `"X"`           |

`face_profile()` calls `corner_profile(faces, convexity=convexity, r=r)` with no `axis`, which falls back to the `"Z"` default — wrong for every face except TOP/BOTTOM. The `edge_profile()` half is unaffected; only the corners are wrong.

## Fix

Derive the revolution axis from the masked face(s)' normal in `face_profile()` and forward it to `corner_profile()`:

```openscad
axis = let(
    nx = [for (f=faces) if (!approx(f.x,0)) true],
    ny = [for (f=faces) if (!approx(f.y,0)) true],
    nz = [for (f=faces) if (!approx(f.z,0)) true]
) len(nx)==0 && len(ny)==0 ? "Z"
  : len(ny)==0 && len(nz)==0 ? "X"
  : len(nx)==0 && len(nz)==0 ? "Y"
  : "Z";
edge_profile(faces, excess=excess) children();
corner_profile(faces, convexity=convexity, r=r, axis=axis) children();
```

When `faces` spans more than one axis the corner axis is ambiguous (`corner_profile()` only accepts a single axis), so the code falls back to the historical `"Z"` default to avoid changing existing multi-face behavior.

## Verification

Rendered each face separately and rotated the non-TOP cases onto the TOP orientation, then compared pixel-by-pixel against the TOP reference (OpenSCAD 2026.06.12, $fn=64, ImageMagick `compare -metric AE`):

| Case                          | Differing pixels vs TOP reference |
|-------------------------------|-----------------------------------|
| FRONT, axis=Y (fixed)         | 0 (identical, antialiasing only)  |
| FRONT, axis=Z (current)       | ~7800                             |
| LEFT,  axis=X (fixed)         | 0 (identical)                     |
| LEFT,  axis=Z (current)       | ~8900                             |

After the fix all three faces render identically, restoring the expected cuboid symmetry. Existing single-axis TOP/BOTTOM usage is unchanged.

## Backward compatibility

TOP/BOTTOM behavior is unchanged (axis still resolves to `"Z"`). Multi-face calls that previously relied on the implicit `"Z"` default keep the same behavior. Only single-axis FRONT/BACK/LEFT/RIGHT calls — which were previously incorrect — change.