### PR TITLE
Run the docs and tutorials checks through BelfrySCAD, and add a full render workflow

### DIFF
--- a/.github/workflows/gen_docs_belfryscad.yml
+++ b/.github/workflows/gen_docs_belfryscad.yml
@@ -29,16 +29,16 @@ jobs:
     timeout-minutes: 90
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Clone Wiki
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: BelfrySCAD/BOSL2.wiki
         path: BOSL2.wiki
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 
@@ -54,7 +54,7 @@ jobs:
     # so a partial run can still be inspected.
     - name: Upload generated docs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: bosl2-wiki-belfryscad
         path: BOSL2.wiki

--- a/.github/workflows/gen_docs_belfryscad.yml
+++ b/.github/workflows/gen_docs_belfryscad.yml
@@ -1,0 +1,68 @@
+# Full documentation build rendered by BelfrySCAD rather than the OpenSCAD
+# binary. Manually runnable only, and it does NOT touch the live wiki
+# unless you ask it to: the default run leaves the result as a downloadable
+# artifact so the images can be compared against the current wiki first.
+#
+# This is the render-everything counterpart to the Checks workflow's
+# CheckDocs job, which runs the same tool with -T (execute every script,
+# generate no images).
+name: Regenerate Docs (BelfrySCAD)
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish_to_wiki:
+        description: "Push the generated docs to the live wiki (overwrites it)"
+        type: boolean
+        default: false
+
+jobs:
+  RegenerateDocs:
+    # macOS, not ubuntu: this job actually renders, and a mac runner has a
+    # real GL implementation. On Linux the offscreen renderer falls back to
+    # EGL against software Mesa, which is both slower and one more thing
+    # that can differ from what a developer sees locally. CheckDocs stays
+    # on ubuntu because -T renders nothing.
+    runs-on: macos-latest
+    # A full render is 44-60 minutes; 90 leaves headroom without letting a
+    # hung run burn the whole 6-hour job limit.
+    timeout-minutes: 90
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Clone Wiki
+      uses: actions/checkout@v4
+      with:
+        repository: BelfrySCAD/BOSL2.wiki
+        path: BOSL2.wiki
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install BelfrySCAD
+      run: pip install belfryscad
+
+    - name: Generate Docs
+      env:
+        OPENSCADPATH: ${{ github.workspace }}/..
+      run: belfryscad --docsgen -f
+
+    # Uploaded whether or not the wiki gets published, and on failure too,
+    # so a partial run can still be inspected.
+    - name: Upload generated docs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: bosl2-wiki-belfryscad
+        path: BOSL2.wiki
+
+    - name: Upload Docs to Wiki
+      if: ${{ inputs.publish_to_wiki }}
+      uses: SwiftDocOrg/github-wiki-publish-action@v1
+      with:
+        path: "BOSL2.wiki"
+      env:
+        GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,21 +68,16 @@ jobs:
         repository: BelfrySCAD/BOSL2.wiki
         path: BOSL2.wiki
 
-    - name: Apt Update
-      run: sudo apt update
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
 
-    - name: Install Required Libraries
-      run: sudo apt-get install python3-pip python3-dev python3-setuptools python3-pil libfuse2
-
-    - name: Install OpenSCAD-DocsGen package.
-      run: sudo pip3 install openscad-docsgen imageio
-
-    - name: Install OpenSCAD
-      run: |
-        cd $GITHUB_WORKSPACE
-        wget -q https://github.com/openscad/openscad/releases/download/openscad-2021.01/OpenSCAD-2021.01-x86_64.AppImage
-        sudo mv OpenSCAD-2021.01*-x86_64.AppImage /usr/local/bin/openscad
-        sudo chmod +x /usr/local/bin/openscad
+    # Same swap as CheckDocs below, and same reason there are no GL
+    # libraries: --mdimggen -T executes every code block but writes no
+    # images, so the renderer is never imported.
+    - name: Install BelfrySCAD
+      run: pip install belfryscad
 
     - name: Tabs Check
       run: |
@@ -95,7 +90,7 @@ jobs:
         cd $GITHUB_WORKSPACE
         echo "::add-matcher::.github/openscad_docsgen.json"
         export OPENSCADPATH=$(dirname $GITHUB_WORKSPACE)
-        openscad-mdimggen -T
+        belfryscad --mdimggen -T
 
   CheckDocs:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,10 +98,11 @@ jobs:
     # (cancelled at 60, having reached 87%); two fixes since then account for
     # ~36% of that: belfryscad no longer parses each example twice (~33%,
     # BelfrySCAD #345) and -T no longer builds geometry it throws away (~3%,
-    # evaluator 1.1.0). 90 minutes is deliberate headroom while the real
-    # figure is unknown -- tighten it once a green run has been timed.
+    # evaluator 1.1.0). Timed green at 45m44s, so 75 keeps roughly the
+    # proportional slack the old 60-minute limit gave that ~41 -- enough for
+    # a slow runner, short enough that a hang is caught not sat through.
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 75
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,12 +93,13 @@ jobs:
         belfryscad --mdimggen -T
 
   CheckDocs:
-    runs-on: ubuntu-latest
-    # 120, not 60. Measured on this runner: openscad-docsgen took a steady
-    # ~41 minutes, belfryscad --docsgen needs ~69 -- it reached 87% when the
-    # old 60-minute limit cancelled it. Slower per script, but it replaces
-    # a process launch per Example with in-process evaluation, so the gap is
-    # in the evaluator rather than in startup overhead.
+    # macOS purely for CPU speed -- -T renders nothing, so this job needs no
+    # GL at all. On ubuntu the swapped job wanted ~69 minutes (it reached 87%
+    # when a 60-minute limit cancelled it), against a steady ~41 for the
+    # openscad-docsgen setup it replaces. The same command over the same
+    # library takes 33m23s on a developer's Mac, so the runner was the
+    # variable, not a hang.
+    runs-on: macos-latest
     timeout-minutes: 120
     steps:
     - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 20
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install Required Libraries
       run: sudo apt-get install libfuse2
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Check Function Test Coverage
       run: |
@@ -60,16 +60,16 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Clone Wiki
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: BelfrySCAD/BOSL2.wiki
         path: BOSL2.wiki
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 
@@ -105,16 +105,16 @@ jobs:
     timeout-minutes: 75
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Clone Wiki
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: BelfrySCAD/BOSL2.wiki
         path: BOSL2.wiki
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,12 @@ jobs:
 
   CheckDocs:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # 120, not 60. Measured on this runner: openscad-docsgen took a steady
+    # ~41 minutes, belfryscad --docsgen needs ~69 -- it reached 87% when the
+    # old 60-minute limit cancelled it. Slower per script, but it replaces
+    # a process launch per Example with in-process evaluation, so the gap is
+    # in the evaluator rather than in startup overhead.
+    timeout-minutes: 120
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,25 +110,26 @@ jobs:
         repository: BelfrySCAD/BOSL2.wiki
         path: BOSL2.wiki
 
-    - name: Apt Update
-      run: sudo apt update
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
 
-    - name: Install Required Libraries
-      run: sudo apt-get install python3-pip python3-dev python3-setuptools python3-pil libfuse2
-
-    - name: Install OpenSCAD-DocsGen package.
-      run: sudo pip3 install openscad-docsgen imageio
-
-    - name: Install OpenSCAD
-      run: |
-        cd $GITHUB_WORKSPACE
-        wget -q https://github.com/openscad/openscad/releases/download/openscad-2021.01/OpenSCAD-2021.01-x86_64.AppImage
-        sudo mv OpenSCAD-2021.01*-x86_64.AppImage /usr/local/bin/openscad
-        sudo chmod +x /usr/local/bin/openscad
+    # BelfrySCAD replaces openscad-docsgen AND the OpenSCAD binary: it
+    # takes the same options and emits the same markdown, but runs
+    # Examples and Figures through its own evaluator. So no AppImage and
+    # no libfuse2.
+    #
+    # No GL libraries either. -T executes every script but generates no
+    # images, and the renderer is imported lazily at the point an image
+    # would be written, so a test-only run loads neither moderngl nor
+    # PySide6. The full-render workflow does need them.
+    - name: Install BelfrySCAD
+      run: pip install belfryscad
 
     - name: Checking Docs
       run: |
         cd $GITHUB_WORKSPACE
         echo "::add-matcher::.github/openscad_docsgen.json"
         export OPENSCADPATH=$(dirname $GITHUB_WORKSPACE)
-        openscad-docsgen -Tmf
+        belfryscad --docsgen -Tmf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,14 +93,15 @@ jobs:
         belfryscad --mdimggen -T
 
   CheckDocs:
-    # macOS purely for CPU speed -- -T renders nothing, so this job needs no
-    # GL at all. On ubuntu the swapped job wanted ~69 minutes (it reached 87%
-    # when a 60-minute limit cancelled it), against a steady ~41 for the
-    # openscad-docsgen setup it replaces. The same command over the same
-    # library takes 33m23s on a developer's Mac, so the runner was the
-    # variable, not a hang.
-    runs-on: macos-latest
-    timeout-minutes: 120
+    # Back on ubuntu, so this is directly comparable with the ~41 minutes
+    # openscad-docsgen held here for years. The first swapped run wanted ~69
+    # (cancelled at 60, having reached 87%); two fixes since then account for
+    # ~36% of that: belfryscad no longer parses each example twice (~33%,
+    # BelfrySCAD #345) and -T no longer builds geometry it throws away (~3%,
+    # evaluator 1.1.0). 90 minutes is deliberate headroom while the real
+    # figure is unknown -- tighten it once a green run has been timed.
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
## 1. `CheckDocs` now uses BelfrySCAD

```diff
- openscad-docsgen -Tmf     # + OpenSCAD 2021.01 AppImage
+ belfryscad --docsgen -Tmf
```

Same options, same markdown — but Examples and Figures execute through BelfrySCAD's own evaluator instead of launching the OpenSCAD binary once per script. The AppImage download, `libfuse2`, `openscad-docsgen` and `imageio` installs all go away.

`-T` is `--test-only`: run every script, generate no images. That is what makes it a check rather than a build.

### No GL libraries, deliberately

The renderer is imported lazily, at the point an image would actually be written. A `-T` run therefore loads neither `moderngl` nor `PySide6` — verified by inspecting `sys.modules` after a real `-T` run, not assumed. Please don't add them back "just in case"; if that ever stops being true, the failure will be an obvious `ImportError`.

## 2. `CheckTutorials` now uses BelfrySCAD

```diff
- openscad-mdimggen -T      # + OpenSCAD 2021.01 AppImage
+ belfryscad --mdimggen -T
```

The same swap, for the tutorials' markdown code blocks. Same four installs dropped, same absence of GL libraries, confirmed the same way. The `Tabs Check` step in that job is untouched.

### Left alone

`Regressions` still installs the OpenSCAD AppImage. It runs `openscad-test`, which is a different tool and a separate question.

## 3. New `gen_docs_belfryscad.yml` — manual full render

The render-everything counterpart to the `-T` check.

- **`workflow_dispatch` only.**
- **Runs on `macos-latest`**, so there is a real GL implementation rather than EGL against software Mesa — one less way for CI output to differ from what a developer sees locally.
- **Does not touch the live wiki by default.** It uploads `BOSL2.wiki` as an artifact so the images can be compared first; pushing to the real wiki requires ticking the `publish_to_wiki` input.
- **90-minute timeout**, against an expected 44–60 minute run.

The artifact upload is `if: always()`, so a run that times out or fails partway can still be inspected.

## Verification

- Both files parse; job graphs and the dispatch input checked.
- `OPENSCADPATH` resolution confirmed working with BelfrySCAD (the workflow depends on it to resolve `include <BOSL2/std.scad>`).
- A full local `belfryscad --docsgen -Tmf` over this library is running as of writing — no errors through the first ~335 files' worth of output.
- Opening this PR runs the new `CheckDocs` on real CI, which is the actual test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
