### PR TITLE
Move the remaining workflows off Node 20 actions

### DIFF
--- a/.github/workflows/gen_docs.yml
+++ b/.github/workflows/gen_docs.yml
@@ -7,10 +7,10 @@ jobs:
     timeout-minutes: 90
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Clone Wiki
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: BelfrySCAD/BOSL2.wiki
         path: BOSL2.wiki

--- a/.github/workflows/gen_tutorials.yml
+++ b/.github/workflows/gen_tutorials.yml
@@ -7,10 +7,10 @@ jobs:
     timeout-minutes: 20
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Clone Wiki
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: BelfrySCAD/BOSL2.wiki
         path: BOSL2.wiki

--- a/.github/workflows/version_stamp.yml
+++ b/.github/workflows/version_stamp.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: master
         fetch-depth: 0

--- a/.github/workflows/weekly_release.yml
+++ b/.github/workflows/weekly_release.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: master
         fetch-depth: 0


### PR DESCRIPTION
`actions/checkout` **v4 → v5** in the four workflows PR #2034 does not touch: `gen_docs.yml`, `gen_tutorials.yml`, `version_stamp.yml`, `weekly_release.yml`.

v5 is the **lowest** major declaring `node24`, so the change is the runtime and nothing else. `checkout` is on v7 now, but jumping three majors risks behaviour changes for a warning that is purely about Node.

## This does not silence the deprecation everywhere

`gen_docs.yml` and `gen_tutorials.yml` both use **`GabrielBB/xvfb-action@v1.6`**, which declares **`node12`** — older than the v4 checkout that prompted this, and last touched upstream in 2024. No version bump fixes it; the action would have to be replaced or dropped.

That is a real change to two workflows which publish to the live wiki, so it is left alone here.

**Worth knowing for whoever picks it up:** the BelfrySCAD docs workflow added in #2034 needs no xvfb at all — its renderer uses EGL. If `gen_docs.yml` and `gen_tutorials.yml` ever move to `belfryscad`, the dependency disappears rather than needing a replacement.

`SwiftDocOrg/github-wiki-publish-action@v1` is a Docker action, so it has no Node runtime and is unaffected.

## Checked, not assumed

Each action's `action.yml` `using:` line was read directly. That mattered — `actions/upload-artifact@v5` is **still `node20`**, so the "next number up" would not have been enough there. (That one is in #2034, not this PR.)

All five workflow files still parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)