### PR TITLE
Publish the wiki from a Linux job

### DIFF
--- a/.github/workflows/gen_docs.yml
+++ b/.github/workflows/gen_docs.yml
@@ -60,8 +60,22 @@ jobs:
         name: bosl2-wiki
         path: BOSL2.wiki
 
+  PublishToWiki:
+    needs: RegenerateDocs
+    if: ${{ inputs.publish_to_wiki }}
+    # Linux, not macOS: SwiftDocOrg/github-wiki-publish-action is a Docker
+    # action, and GitHub runs container actions on Linux runners only --
+    # "Container action is only supported on Linux". The render job stays on
+    # macOS for its GL; this job only moves files, so the runner is free.
+    runs-on: ubuntu-latest
+    steps:
+    - name: Fetch the generated docs
+      uses: actions/download-artifact@v7
+      with:
+        name: bosl2-wiki
+        path: BOSL2.wiki
+
     - name: Upload Docs to Wiki
-      if: ${{ inputs.publish_to_wiki }}
       uses: SwiftDocOrg/github-wiki-publish-action@v1
       with:
         path: "BOSL2.wiki"

--- a/.github/workflows/gen_tutorials.yml
+++ b/.github/workflows/gen_tutorials.yml
@@ -57,8 +57,22 @@ jobs:
         name: bosl2-wiki-tutorials
         path: BOSL2.wiki
 
+  PublishToWiki:
+    needs: RegenerateTutorials
+    if: ${{ inputs.publish_to_wiki }}
+    # Linux, not macOS: SwiftDocOrg/github-wiki-publish-action is a Docker
+    # action, and GitHub runs container actions on Linux runners only --
+    # "Container action is only supported on Linux". The render job stays on
+    # macOS for its GL; this job only moves files, so the runner is free.
+    runs-on: ubuntu-latest
+    steps:
+    - name: Fetch the generated docs
+      uses: actions/download-artifact@v7
+      with:
+        name: bosl2-wiki-tutorials
+        path: BOSL2.wiki
+
     - name: Upload Tutorials to Wiki
-      if: ${{ inputs.publish_to_wiki }}
       uses: SwiftDocOrg/github-wiki-publish-action@v1
       with:
         path: "BOSL2.wiki"


### PR DESCRIPTION
A real publish run failed at the last step:

```
##[error]Container action is only supported on Linux
```

`SwiftDocOrg/github-wiki-publish-action` is a **Docker** action, and GitHub runs container actions on Linux runners only. #2036 moved both workflows to macOS for a real GL implementation and took the publish step along with them.

## The fix

The render job **stays on macOS** — that is the part that needs GL. The publish step moves into its own `ubuntu-latest` job that downloads the artifact the render job already uploads and hands it to the same action as before.

No change to *how* the wiki is written, only *where from*.

## Nothing was lost

The docs generated fine in 32 minutes and the artifact uploaded. Only the push failed, so the live wiki is untouched.

## Why CI could not have caught this

Both workflows are `workflow_dispatch`, and the artifact-only run that proved the swap skips the publish behind `if: publish_to_wiki`. The first run that could fail was the first real publish. Flagged as untested at the time; this is that risk landing.

## One detail worth keeping

`download-artifact` is pinned at **v7**, not the v6 used elsewhere in this repo — **v6 is still node20** and would have reinstated a deprecation warning #2035 and #2036 just removed. Each `action.yml`'s `using:` line was checked rather than assuming the highest number already present was current. All four `actions/*` pins are now node24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)