### PR TITLE
Split the docs wiki build into Update and Regenerate

### DIFF
--- a/.github/workflows/regen_docs_wiki.yml
+++ b/.github/workflows/regen_docs_wiki.yml
@@ -1,10 +1,15 @@
-# Full documentation build, rendered by BelfrySCAD's own evaluator rather
-# than by launching the OpenSCAD binary once per image.
+# Rebuilds every image in the wiki from scratch, rendered by BelfrySCAD's
+# own evaluator rather than by launching the OpenSCAD binary once per image.
 #
-# This is the render-everything counterpart to the Checks workflow's
-# CheckDocs job, which runs the same tool with -T (execute every script,
-# generate no images).
-name: Regenerate Docs
+# The forced counterpart to Update Docs Wiki, which re-renders only the
+# sources whose hash changed. Reach for this when the images must be rebuilt
+# for a reason the source hashes cannot see: a change in BelfrySCAD's
+# renderer or evaluator, a colour-scheme change, or a wiki that has drifted
+# and needs to be made consistent again. Costs a full ~35 minutes every time.
+#
+# Never triggered by a release -- a release publishes the library, and
+# Update Docs Wiki is enough to describe it.
+name: Regenerate Docs Wiki
 
 on:
   workflow_dispatch:
@@ -15,7 +20,7 @@ on:
         default: true
 
 jobs:
-  RegenerateDocs:
+  RegenerateDocsWiki:
     # macOS for a real GL implementation. This job actually renders; on
     # Linux the offscreen renderer falls back to EGL against software Mesa,
     # which is slower and one more way for CI output to differ from what a
@@ -61,7 +66,7 @@ jobs:
         path: BOSL2.wiki
 
   PublishToWiki:
-    needs: RegenerateDocs
+    needs: RegenerateDocsWiki
     if: ${{ inputs.publish_to_wiki }}
     # Linux, not macOS: SwiftDocOrg/github-wiki-publish-action is a Docker
     # action, and GitHub runs container actions on Linux runners only --

--- a/.github/workflows/update_docs_wiki.yml
+++ b/.github/workflows/update_docs_wiki.yml
@@ -15,15 +15,23 @@ on:
         description: "Push the generated docs to the live wiki (overwrites it)"
         type: boolean
         default: true
-  # A release ships the library; the wiki should describe what shipped.
+  # Called by weekly_release.yml, and only when it actually creates a
+  # release -- most weeks it finds one already exists for the latest tag and
+  # does nothing.
   #
-  # CAVEAT: this fires for a release published by hand, or by anything using
-  # a PAT -- but NOT for the weekly one. GitHub deliberately raises no event
-  # for actions taken with the default GITHUB_TOKEN, to stop workflows
-  # triggering each other in a loop, and weekly_release.yml creates its
-  # release with `GH_TOKEN: ${{ github.token }}`. To make the weekly release
-  # reach this workflow, that job has to create the release with a PAT
-  # (secrets.GH_PAT) instead.
+  # A call, not an event, on purpose. GitHub raises no event for anything
+  # done with the default GITHUB_TOKEN, to stop workflows setting each other
+  # off in a loop, and that job creates its release with exactly that token.
+  # So `release: published` below never sees the weekly one. A workflow_call
+  # runs inside the caller's own run, raises no event, and needs no PAT.
+  workflow_call:
+    inputs:
+      publish_to_wiki:
+        type: boolean
+        default: true
+
+  # Still useful for a release published by hand or by anything holding a
+  # PAT; the weekly path comes through workflow_call above.
   release:
     types: [published]
 

--- a/.github/workflows/update_docs_wiki.yml
+++ b/.github/workflows/update_docs_wiki.yml
@@ -1,0 +1,98 @@
+# Brings the wiki up to date with the library, rendered by BelfrySCAD's own
+# evaluator rather than by launching the OpenSCAD binary once per image.
+#
+# Incremental: docsgen keeps a hash per source file and re-renders only what
+# changed, so a run after a small edit costs minutes rather than the ~35 a
+# full render takes. Use Regenerate Docs Wiki when every image has to be
+# rebuilt regardless -- after a renderer change, say, which the hashes
+# cannot see.
+name: Update Docs Wiki
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish_to_wiki:
+        description: "Push the generated docs to the live wiki (overwrites it)"
+        type: boolean
+        default: true
+  # A release ships the library; the wiki should describe what shipped.
+  #
+  # CAVEAT: this fires for a release published by hand, or by anything using
+  # a PAT -- but NOT for the weekly one. GitHub deliberately raises no event
+  # for actions taken with the default GITHUB_TOKEN, to stop workflows
+  # triggering each other in a loop, and weekly_release.yml creates its
+  # release with `GH_TOKEN: ${{ github.token }}`. To make the weekly release
+  # reach this workflow, that job has to create the release with a PAT
+  # (secrets.GH_PAT) instead.
+  release:
+    types: [published]
+
+jobs:
+  UpdateDocsWiki:
+    # macOS for a real GL implementation. This job actually renders; on
+    # Linux the offscreen renderer falls back to EGL against software Mesa,
+    # which is slower and one more way for CI output to differ from what a
+    # developer sees locally. CheckDocs stays on ubuntu because -T renders
+    # nothing at all.
+    runs-on: macos-latest
+    timeout-minutes: 90
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Clone Wiki
+      uses: actions/checkout@v5
+      with:
+        repository: BelfrySCAD/BOSL2.wiki
+        path: BOSL2.wiki
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.12"
+
+    # BelfrySCAD replaces openscad-docsgen AND the OpenSCAD binary. Gone
+    # with them: the AppImage download, libfuse2, imageio, python3-pil, and
+    # xvfb -- the renderer is offscreen, so there is no X server for a
+    # virtual display to stand in for. gifsicle went too; APNG is always
+    # used, so no GIF is ever written to optimise.
+    - name: Install BelfrySCAD
+      run: pip install belfryscad
+
+    - name: Generate Docs
+      env:
+        OPENSCADPATH: ${{ github.workspace }}/..
+      run: belfryscad --docsgen
+
+    # Uploaded whether or not the wiki gets published, and on failure too,
+    # so a partial or unpublished run can still be inspected.
+    - name: Upload generated docs
+      if: always()
+      uses: actions/upload-artifact@v6
+      with:
+        name: bosl2-wiki
+        path: BOSL2.wiki
+
+  PublishToWiki:
+    needs: UpdateDocsWiki
+    # `inputs` is empty on a release event, so testing it alone would skip
+    # the publish on precisely the run that must not skip it.
+    if: ${{ github.event_name == 'release' || inputs.publish_to_wiki }}
+    # Linux, not macOS: SwiftDocOrg/github-wiki-publish-action is a Docker
+    # action, and GitHub runs container actions on Linux runners only --
+    # "Container action is only supported on Linux". The render job stays on
+    # macOS for its GL; this job only moves files, so the runner is free.
+    runs-on: ubuntu-latest
+    steps:
+    - name: Fetch the generated docs
+      uses: actions/download-artifact@v7
+      with:
+        name: bosl2-wiki
+        path: BOSL2.wiki
+
+    - name: Upload Docs to Wiki
+      uses: SwiftDocOrg/github-wiki-publish-action@v1
+      with:
+        path: "BOSL2.wiki"
+      env:
+        GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/weekly_release.yml
+++ b/.github/workflows/weekly_release.yml
@@ -11,6 +11,11 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+    outputs:
+      # Whether this run actually cut a release, so the wiki is only rebuilt
+      # when there is something new to describe. Most weeks the latest tag
+      # already has one and nothing happens.
+      created: ${{ steps.create_release.outputs.created }}
     steps:
     - name: Checkout
       uses: actions/checkout@v5
@@ -47,11 +52,23 @@ jobs:
         GH_TOKEN: ${{ github.token }}
 
     - name: Create release
+      id: create_release
       if: steps.find_tag.outputs.has_tag == 'true' && steps.check_release.outputs.exists == 'false'
       run: |
         TAG="${{ steps.find_tag.outputs.tag }}"
         # Try with auto-generated notes; fall back to simple notes if body is too long
         gh release create "$TAG" --title "$TAG" --generate-notes || \
           gh release create "$TAG" --title "$TAG" --notes "Release ${TAG}"
+        echo "created=true" >> "$GITHUB_OUTPUT"
       env:
         GH_TOKEN: ${{ github.token }}
+
+  # Refresh the wiki for what just shipped. Called rather than triggered:
+  # GitHub raises no event for a release created with the default
+  # GITHUB_TOKEN, so `release: published` would never fire for the release
+  # made above. A workflow_call runs inside this run and needs no PAT.
+  UpdateWiki:
+    needs: release
+    if: needs.release.outputs.created == 'true'
+    uses: ./.github/workflows/update_docs_wiki.yml
+    secrets: inherit


### PR DESCRIPTION
Two jobs that were one. Rendering every image takes ~35 minutes, and most of the time nothing needs rendering but the handful of files that changed.

| workflow | command | |
|---|---|---|
| **Update Docs Wiki** | `belfryscad --docsgen` | incremental |
| **Regenerate Docs Wiki** | `belfryscad --docsgen -f` | rebuilds everything |

docsgen keeps a hash per source file, so the incremental run re-renders only what changed and costs minutes after a small edit. The forced one exists for the changes those hashes **cannot see** — a renderer or evaluator change, a colour scheme, or a wiki that has drifted and needs making consistent again.

## Release trigger

**Update Docs Wiki** also runs when a release is published, so shipping the library refreshes the pages describing it.

### The weekly release calls it directly

`release: published` does **not** work for the release that matters. GitHub raises no event for anything done with the default `GITHUB_TOKEN` — a deliberate guard against workflows setting each other off — and `weekly_release.yml` creates its release with exactly that token. The trigger would have sat there looking correct and never firing.

So the weekly release **calls** the docs workflow rather than hoping an event reaches it:

```yaml
  UpdateWiki:
    needs: release
    if: needs.release.outputs.created == 'true'
    uses: ./.github/workflows/update_docs_wiki.yml
    secrets: inherit
```

A `workflow_call` runs inside the caller's own run: no event is raised, so nothing is suppressed, and no PAT is needed to work around it.

**Gated on a release actually being cut.** The weekly job usually finds the latest tag already has a release and does nothing — rebuilding the wiki on those weeks would burn ~35 minutes of a mac runner for no change. The release job now reports `created`, and the wiki job runs only when that is true.

`release: published` stays as a trigger; it is still right for a release published by hand or by anything holding a PAT.

## A bug this surfaced

The publish job could no longer test `inputs.publish_to_wiki` alone: a **release event carries no inputs**, so that check evaluates false on precisely the run that must publish. It now passes for a release *or* a ticked input:

```yaml
if: ${{ github.event_name == 'release' || inputs.publish_to_wiki }}
```

## Files

`gen_docs.yml` is renamed to `regen_docs_wiki.yml` (git tracks it as a rename), and `update_docs_wiki.yml` is the new incremental one. Both keep the macOS render / Linux publish split from #2038.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
