### PR TITLE
Publish the wiki's images, not just its markdown

### DIFF
--- a/.github/workflows/gen_tutorials.yml
+++ b/.github/workflows/gen_tutorials.yml
@@ -55,7 +55,18 @@ jobs:
       uses: actions/upload-artifact@v6
       with:
         name: bosl2-wiki-tutorials
-        path: BOSL2.wiki
+        # Hidden files included deliberately. The publish step mirrors this
+        # artifact over the wiki with rsync --delete, and .source_hashes --
+        # docsgen's record of what it has already rendered -- is a dotfile.
+        # Left out, every publish would delete it and the next incremental
+        # run would have to render the whole library again. .gitignore too.
+        # .git is excluded: the wiki clone's history is not ours to ship,
+        # and the publish step clones the wiki itself.
+        include-hidden-files: true
+        path: |
+          BOSL2.wiki
+          !BOSL2.wiki/.git
+          !BOSL2.wiki/.git/**
 
   PublishToWiki:
     needs: RegenerateTutorials
@@ -73,8 +84,35 @@ jobs:
         path: BOSL2.wiki
 
     - name: Upload Tutorials to Wiki
-      uses: SwiftDocOrg/github-wiki-publish-action@v1
-      with:
-        path: "BOSL2.wiki"
       env:
-        GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PAT }}
+        GH_PAT: ${{ secrets.GH_PAT }}
+      run: |
+        # Not SwiftDocOrg/github-wiki-publish-action: its entrypoint copies
+        # only `find "$path" -maxdepth 1 -type f -name '*.md'`, so it has
+        # never published an image or anything in a subdirectory. Every run
+        # looked successful and pushed markdown alone, which is why the
+        # wiki's images were still the ones from before BelfrySCAD rendered
+        # them.
+        #
+        # A wiki is an ordinary git repo, so this just is one: clone, mirror
+        # the generated tree over it, commit, push. rsync --delete makes the
+        # wiki match what was generated, which also retires an image whose
+        # example was removed or marked NORENDER -- the action could not do
+        # that either.
+        set -euo pipefail
+        wiki=$(mktemp -d)
+        git clone --depth 1 \
+          "https://x-access-token:${GH_PAT}@github.com/${GITHUB_REPOSITORY}.wiki.git" "$wiki"
+        rsync -a --delete --exclude '.git/' BOSL2.wiki/ "$wiki"/
+        cd "$wiki"
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add -A
+        if git diff --cached --quiet; then
+          echo "Wiki already matches the generated docs; nothing to publish."
+          exit 0
+        fi
+        git commit -m "Update tutorials from ${GITHUB_SHA:0:8}"
+        git push origin HEAD:master
+        echo "Published:"
+        git show --stat --oneline HEAD | tail -5

--- a/.github/workflows/gen_tutorials.yml
+++ b/.github/workflows/gen_tutorials.yml
@@ -103,7 +103,17 @@ jobs:
         wiki=$(mktemp -d)
         git clone --depth 1 \
           "https://x-access-token:${GH_PAT}@github.com/${GITHUB_REPOSITORY}.wiki.git" "$wiki"
-        rsync -a --delete --exclude '.git/' BOSL2.wiki/ "$wiki"/
+        # --checksum, not rsync's default size-and-mtime quick check: an
+        # image that changes without changing size is otherwise skipped
+        # silently, which is precisely the failure this step exists to fix.
+        # Hashing ~80MB costs seconds.
+        #
+        # --exclude '.git/' protects the clone's own history: rsync does not
+        # delete what it excludes, unless asked with --delete-excluded.
+        # Verified both, rather than trusted: a local run of this exact
+        # command updated a same-size file, removed a stale one, and left
+        # .git intact.
+        rsync -a --checksum --delete --exclude '.git/' BOSL2.wiki/ "$wiki"/
         cd "$wiki"
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/gen_tutorials.yml
+++ b/.github/workflows/gen_tutorials.yml
@@ -71,10 +71,10 @@ jobs:
   PublishToWiki:
     needs: RegenerateTutorials
     if: ${{ inputs.publish_to_wiki }}
-    # Linux, not macOS: SwiftDocOrg/github-wiki-publish-action is a Docker
-    # action, and GitHub runs container actions on Linux runners only --
-    # "Container action is only supported on Linux". The render job stays on
-    # macOS for its GL; this job only moves files, so the runner is free.
+    # ubuntu because this job only moves files -- the render job stays on
+    # macOS for its GL. It used to have to be Linux, because the publish was
+    # a Docker action and GitHub runs those on Linux only; that action is
+    # gone now, so this is a choice rather than a constraint.
     runs-on: ubuntu-latest
     steps:
     - name: Fetch the generated docs

--- a/.github/workflows/regen_docs_wiki.yml
+++ b/.github/workflows/regen_docs_wiki.yml
@@ -63,7 +63,18 @@ jobs:
       uses: actions/upload-artifact@v6
       with:
         name: bosl2-wiki
-        path: BOSL2.wiki
+        # Hidden files included deliberately. The publish step mirrors this
+        # artifact over the wiki with rsync --delete, and .source_hashes --
+        # docsgen's record of what it has already rendered -- is a dotfile.
+        # Left out, every publish would delete it and the next incremental
+        # run would have to render the whole library again. .gitignore too.
+        # .git is excluded: the wiki clone's history is not ours to ship,
+        # and the publish step clones the wiki itself.
+        include-hidden-files: true
+        path: |
+          BOSL2.wiki
+          !BOSL2.wiki/.git
+          !BOSL2.wiki/.git/**
 
   PublishToWiki:
     needs: RegenerateDocsWiki
@@ -81,8 +92,35 @@ jobs:
         path: BOSL2.wiki
 
     - name: Upload Docs to Wiki
-      uses: SwiftDocOrg/github-wiki-publish-action@v1
-      with:
-        path: "BOSL2.wiki"
       env:
-        GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PAT }}
+        GH_PAT: ${{ secrets.GH_PAT }}
+      run: |
+        # Not SwiftDocOrg/github-wiki-publish-action: its entrypoint copies
+        # only `find "$path" -maxdepth 1 -type f -name '*.md'`, so it has
+        # never published an image or anything in a subdirectory. Every run
+        # looked successful and pushed markdown alone, which is why the
+        # wiki's images were still the ones from before BelfrySCAD rendered
+        # them.
+        #
+        # A wiki is an ordinary git repo, so this just is one: clone, mirror
+        # the generated tree over it, commit, push. rsync --delete makes the
+        # wiki match what was generated, which also retires an image whose
+        # example was removed or marked NORENDER -- the action could not do
+        # that either.
+        set -euo pipefail
+        wiki=$(mktemp -d)
+        git clone --depth 1 \
+          "https://x-access-token:${GH_PAT}@github.com/${GITHUB_REPOSITORY}.wiki.git" "$wiki"
+        rsync -a --delete --exclude '.git/' BOSL2.wiki/ "$wiki"/
+        cd "$wiki"
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add -A
+        if git diff --cached --quiet; then
+          echo "Wiki already matches the generated docs; nothing to publish."
+          exit 0
+        fi
+        git commit -m "Regenerate docs from ${GITHUB_SHA:0:8}"
+        git push origin HEAD:master
+        echo "Published:"
+        git show --stat --oneline HEAD | tail -5

--- a/.github/workflows/regen_docs_wiki.yml
+++ b/.github/workflows/regen_docs_wiki.yml
@@ -79,10 +79,10 @@ jobs:
   PublishToWiki:
     needs: RegenerateDocsWiki
     if: ${{ inputs.publish_to_wiki }}
-    # Linux, not macOS: SwiftDocOrg/github-wiki-publish-action is a Docker
-    # action, and GitHub runs container actions on Linux runners only --
-    # "Container action is only supported on Linux". The render job stays on
-    # macOS for its GL; this job only moves files, so the runner is free.
+    # ubuntu because this job only moves files -- the render job stays on
+    # macOS for its GL. It used to have to be Linux, because the publish was
+    # a Docker action and GitHub runs those on Linux only; that action is
+    # gone now, so this is a choice rather than a constraint.
     runs-on: ubuntu-latest
     steps:
     - name: Fetch the generated docs

--- a/.github/workflows/regen_docs_wiki.yml
+++ b/.github/workflows/regen_docs_wiki.yml
@@ -111,7 +111,17 @@ jobs:
         wiki=$(mktemp -d)
         git clone --depth 1 \
           "https://x-access-token:${GH_PAT}@github.com/${GITHUB_REPOSITORY}.wiki.git" "$wiki"
-        rsync -a --delete --exclude '.git/' BOSL2.wiki/ "$wiki"/
+        # --checksum, not rsync's default size-and-mtime quick check: an
+        # image that changes without changing size is otherwise skipped
+        # silently, which is precisely the failure this step exists to fix.
+        # Hashing ~80MB costs seconds.
+        #
+        # --exclude '.git/' protects the clone's own history: rsync does not
+        # delete what it excludes, unless asked with --delete-excluded.
+        # Verified both, rather than trusted: a local run of this exact
+        # command updated a same-size file, removed a stale one, and left
+        # .git intact.
+        rsync -a --checksum --delete --exclude '.git/' BOSL2.wiki/ "$wiki"/
         cd "$wiki"
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/update_docs_wiki.yml
+++ b/.github/workflows/update_docs_wiki.yml
@@ -129,7 +129,17 @@ jobs:
         wiki=$(mktemp -d)
         git clone --depth 1 \
           "https://x-access-token:${GH_PAT}@github.com/${GITHUB_REPOSITORY}.wiki.git" "$wiki"
-        rsync -a --delete --exclude '.git/' BOSL2.wiki/ "$wiki"/
+        # --checksum, not rsync's default size-and-mtime quick check: an
+        # image that changes without changing size is otherwise skipped
+        # silently, which is precisely the failure this step exists to fix.
+        # Hashing ~80MB costs seconds.
+        #
+        # --exclude '.git/' protects the clone's own history: rsync does not
+        # delete what it excludes, unless asked with --delete-excluded.
+        # Verified both, rather than trusted: a local run of this exact
+        # command updated a same-size file, removed a stale one, and left
+        # .git intact.
+        rsync -a --checksum --delete --exclude '.git/' BOSL2.wiki/ "$wiki"/
         cd "$wiki"
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/update_docs_wiki.yml
+++ b/.github/workflows/update_docs_wiki.yml
@@ -97,10 +97,10 @@ jobs:
     # `inputs` is empty on a release event, so testing it alone would skip
     # the publish on precisely the run that must not skip it.
     if: ${{ github.event_name == 'release' || inputs.publish_to_wiki }}
-    # Linux, not macOS: SwiftDocOrg/github-wiki-publish-action is a Docker
-    # action, and GitHub runs container actions on Linux runners only --
-    # "Container action is only supported on Linux". The render job stays on
-    # macOS for its GL; this job only moves files, so the runner is free.
+    # ubuntu because this job only moves files -- the render job stays on
+    # macOS for its GL. It used to have to be Linux, because the publish was
+    # a Docker action and GitHub runs those on Linux only; that action is
+    # gone now, so this is a choice rather than a constraint.
     runs-on: ubuntu-latest
     steps:
     - name: Fetch the generated docs

--- a/.github/workflows/update_docs_wiki.yml
+++ b/.github/workflows/update_docs_wiki.yml
@@ -79,7 +79,18 @@ jobs:
       uses: actions/upload-artifact@v6
       with:
         name: bosl2-wiki
-        path: BOSL2.wiki
+        # Hidden files included deliberately. The publish step mirrors this
+        # artifact over the wiki with rsync --delete, and .source_hashes --
+        # docsgen's record of what it has already rendered -- is a dotfile.
+        # Left out, every publish would delete it and the next incremental
+        # run would have to render the whole library again. .gitignore too.
+        # .git is excluded: the wiki clone's history is not ours to ship,
+        # and the publish step clones the wiki itself.
+        include-hidden-files: true
+        path: |
+          BOSL2.wiki
+          !BOSL2.wiki/.git
+          !BOSL2.wiki/.git/**
 
   PublishToWiki:
     needs: UpdateDocsWiki
@@ -99,8 +110,35 @@ jobs:
         path: BOSL2.wiki
 
     - name: Upload Docs to Wiki
-      uses: SwiftDocOrg/github-wiki-publish-action@v1
-      with:
-        path: "BOSL2.wiki"
       env:
-        GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PAT }}
+        GH_PAT: ${{ secrets.GH_PAT }}
+      run: |
+        # Not SwiftDocOrg/github-wiki-publish-action: its entrypoint copies
+        # only `find "$path" -maxdepth 1 -type f -name '*.md'`, so it has
+        # never published an image or anything in a subdirectory. Every run
+        # looked successful and pushed markdown alone, which is why the
+        # wiki's images were still the ones from before BelfrySCAD rendered
+        # them.
+        #
+        # A wiki is an ordinary git repo, so this just is one: clone, mirror
+        # the generated tree over it, commit, push. rsync --delete makes the
+        # wiki match what was generated, which also retires an image whose
+        # example was removed or marked NORENDER -- the action could not do
+        # that either.
+        set -euo pipefail
+        wiki=$(mktemp -d)
+        git clone --depth 1 \
+          "https://x-access-token:${GH_PAT}@github.com/${GITHUB_REPOSITORY}.wiki.git" "$wiki"
+        rsync -a --delete --exclude '.git/' BOSL2.wiki/ "$wiki"/
+        cd "$wiki"
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add -A
+        if git diff --cached --quiet; then
+          echo "Wiki already matches the generated docs; nothing to publish."
+          exit 0
+        fi
+        git commit -m "Update docs from ${GITHUB_SHA:0:8}"
+        git push origin HEAD:master
+        echo "Published:"
+        git show --stat --oneline HEAD | tail -5


### PR DESCRIPTION
**The wiki's images have never been updated by any docs run.**

Not a regression. `SwiftDocOrg/github-wiki-publish-action` cannot do it — its entire copy step is:

```bash
for file in $(find $1 -maxdepth 1 -type f -name '*.md' -execdir basename '{}' ';'); do
    cp "$1/$file" "$tmp_dir"
done
```

Markdown only, top level only. No image, and nothing in any subdirectory, has ever been copied.

Every run reported success and pushed the `.md` files, so nothing looked wrong. The last full regenerate rendered **2594 changed images** into its artifact and published **none** of them — its own log says `nothing to commit, working tree clean`. The images on the wiki are still the ones from before BelfrySCAD ever rendered it.

## The fix

A wiki is an ordinary git repository, so the publish step now is one: clone, mirror the generated tree over it with `rsync`, commit, push.

That is also **the last third-party action gone** from this repo.

### rsync --delete

The wiki now ends up matching what was generated. That fixes a second thing the action could not do: an image whose example was renamed or marked `NORENDER` disappears instead of lingering. 82 such files had to be removed by hand yesterday.

### Hidden files in the artifact

`upload-artifact` excludes dotfiles by default. With `--delete` mirroring, that would have deleted **`.source_hashes`** — docsgen's record of what it has already rendered — from the wiki on every publish, forcing the next *incremental* run to render the whole library. Now included, with `.git` explicitly excluded.

## Applies to all three

`update_docs_wiki.yml`, `regen_docs_wiki.yml` and `gen_tutorials.yml` all used the same action and all had the same hole.

## How to verify after merging

Dispatch **Regenerate Docs Wiki**. The publish step now prints what it pushed; expect ~2594 changed images on the first run, and the wiki's `debug_vnf` and `joiners` figures to finally show the fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)