### PR TITLE
Run the regression suite on BelfrySCAD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     # object file` from Qt. Pinning turns that into a resolver error naming
     # the real problem.
     - name: Install BelfrySCAD
-      run: pip install 'belfryscad>=1.2.0'
+      run: pip install 'belfryscad>=1.2.1'
 
     - name: Run Regression Tests
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,18 +12,17 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v5
 
-    - name: Install Required Libraries
-      run: sudo apt-get install libfuse2
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.12"
 
-    - name: Install OpenSCAD
-      run: |
-        cd $GITHUB_WORKSPACE
-        wget -q https://github.com/openscad/openscad/releases/download/openscad-2021.01/OpenSCAD-2021.01-x86_64.AppImage
-        sudo mv OpenSCAD-2021.01*-x86_64.AppImage /usr/local/bin/openscad
-        sudo chmod +x /usr/local/bin/openscad
-
-    - name: Install openscad-test
-      run: pip install openscad-test
+    # The last job in this repo that downloaded the OpenSCAD AppImage. All
+    # 909 tests pass on BelfrySCAD's evaluator, and run several times faster
+    # in-process than openscad-test's process-per-test. No GL libraries: the
+    # tests execute scripts and check echoes, and nothing renders.
+    - name: Install BelfrySCAD
+      run: pip install belfryscad
 
     - name: Run Regression Tests
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,8 +21,17 @@ jobs:
     # 909 tests pass on BelfrySCAD's evaluator, and run several times faster
     # in-process than openscad-test's process-per-test. No GL libraries: the
     # tests execute scripts and check echoes, and nothing renders.
+    # Version-pinned deliberately. `--test` arrived in 1.2.0, and an older
+    # belfryscad does not reject the flag -- it parses the command line with
+    # parse_known_args, ignores what it does not know, and treats the
+    # .scadtest files as a model to open, launching the GUI. That is exactly
+    # what happened the first time this job ran: pip picked up 1.0.7 because
+    # 1.2.0 was minutes old and had not reached that runner's index yet, and
+    # the failure surfaced as an unrelated `libEGL.so.1: cannot open shared
+    # object file` from Qt. Pinning turns that into a resolver error naming
+    # the real problem.
     - name: Install BelfrySCAD
-      run: pip install belfryscad
+      run: pip install 'belfryscad>=1.2.0'
 
     - name: Run Regression Tests
       run: |

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -14,7 +14,10 @@ if (( ${#INFILES[@]} == 0 )); then
     INFILES=(tests/test_*.scadtest)
 fi
 
-if command -v belfryscad > /dev/null 2>&1; then
+# `--test` needs belfryscad 1.2.0 or newer. An older one ignores the flag
+# rather than rejecting it and tries to open the .scadtest files in the GUI,
+# so check for the subcommand rather than just the binary.
+if command -v belfryscad > /dev/null 2>&1 && belfryscad --test --help > /dev/null 2>&1; then
     belfryscad --test "${INFILES[@]}"
 else
     echo "belfryscad not found; falling back to openscad-test." >&2

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,8 +1,22 @@
 #!/bin/bash
 
+# Runs the .scadtest suite. `belfryscad --test` is a drop-in replacement for
+# openscad-test -- same TOML format, same output, same exit code -- but runs
+# the scripts in-process instead of launching the OpenSCAD binary once per
+# test, which makes it several times faster and removes the dependency on a
+# downloaded OpenSCAD AppImage.
+#
+# Falls back to openscad-test when belfryscad is not installed, so a
+# checkout without it still tests the way it always did.
+
 INFILES=("$@")
 if (( ${#INFILES[@]} == 0 )); then
     INFILES=(tests/test_*.scadtest)
 fi
 
-openscad-test "${INFILES[@]}"
+if command -v belfryscad > /dev/null 2>&1; then
+    belfryscad --test "${INFILES[@]}"
+else
+    echo "belfryscad not found; falling back to openscad-test." >&2
+    openscad-test "${INFILES[@]}"
+fi


### PR DESCRIPTION
The last job in this repo that downloaded the OpenSCAD AppImage.

`CheckDocs` and `CheckTutorials` moved to `belfryscad --docsgen`/`--mdimggen` in #2034. `Regressions` kept `openscad-test` — and with it `libfuse2` and a 2021.01 binary — because nothing could run `.scadtest` files yet.

## `belfryscad --test` now can

A drop-in replacement: same TOML format, same output, same exit code. It runs each script **in-process** instead of launching OpenSCAD once per test.

**All 909 tests pass**, verified against a clean `pip install belfryscad==1.2.0` rather than a development build:

```
909 of 909 tests passed, 0 failed.
```

It is also faster: **~80 seconds serial** for all 909, where openscad-test needs 8.3s for 226 with 5-way parallelism.

## run_tests.sh keeps working either way

It prefers `belfryscad` and falls back to `openscad-test` when that is not installed, so a checkout without BelfrySCAD still tests exactly as before — and the script stays the single entry point for CI and for anyone running it by hand. Both paths were exercised locally.

## What it took

Five parity fixes in the evaluator, **each one found by this suite**:

| fix | tests it was failing |
|---|---|
| function literals stringify as their source | 61 |
| `each` expands strings and ranges (also fixed `str_strip`, `format`, `format_float`) | 4 |
| two empty ranges compare equal (`typeof`) | 1 |
| `search()` binds the documented parameter names (`in_list`) | 1 |
| strings are characters, not bytes (`echo_matrix`) | 1 |

841 → 909. The last one also fixed a real bug beyond the suite: indexing a non-ASCII string used to raise an invalid-UTF-8 error rather than return a character.

Requires `belfryscad >= 1.2.0` with `openscad_cpp_evaluator >= 1.3.0`, both on PyPI.

## After this

No workflow in this repository downloads or runs the OpenSCAD binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)